### PR TITLE
Clear diagnostics when closing file

### DIFF
--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -173,6 +173,13 @@ export class LspServer {
         this.logger.log('onDidCloseTextDocument', params, path);
         this.tspClient.notify(CommandTypes.Close, { file: path });
         this.openedDocumentUris.delete(params.textDocument.uri)
+
+        // We won't be updating diagnostics anymore for that file, so clear them
+        // so we don't leave stale ones.
+        this.options.lspClient.publishDiagnostics({
+            uri: params.textDocument.uri,
+            diagnostics: [],
+        });
     }
 
     public didChangeTextDocument(params: lsp.DidChangeTextDocumentParams): void {


### PR DESCRIPTION
When the user closes a file which has some errors/warnings, we currently
leave those diagnostics in place.  However, this language server doesn't
provide diagnostic for closed files.  This means that the diagnostics
won't get updated until the user re-opens that file.  They can therefore
get stale, if the error or warning condition disappears while the file
is closed.

This patch makes it so that when a file is closed, we clear the
diagnostics associated to that file.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>