### PR TITLE
Add skipLibCheck to tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
         "outDir": "lib",
         "alwaysStrict": true,
         "declaration": true,
-        "strictNullChecks": true
+        "strictNullChecks": true,
+        "skipLibCheck": true
     },
     "include": [
         "src"


### PR DESCRIPTION
When including this package as a dependency of another package, the
Typescript is recompiled as part of the postinstall step.  Some other
modules in node_modules may include some Typescript definition which are
picked up by tsc.  If these files include types unknown when compiling
typescript-language-server (like types from the "dom" library),
compilation will fail with a bunch of errors like:

  ../@types/jsdom/index.d.ts(19,36): error TS2304: Cannot find name 'DocumentFragment'.

even though these types are not necessary to actually build
typescript-language-server.  This happens for example when using the
master branch of this repo in Theia's typescript extension.

This patch adds "skipLibCheck" to tsconfig.json so that we'll just
ignore these unknown types.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>