### PR TITLE
send configure command before formatting command

### DIFF
--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -430,6 +430,11 @@ export class LspServer {
             this.logger.log("No formatting options found " + err)
         }
 
+        // options are not yet supported in tsserver, but we can send a configure request first
+        this.tspClient.request(CommandTypes.Configure, <tsp.ConfigureRequestArguments>{
+            formatOptions: opts
+        });
+
         const response = await this.tspClient.request(CommandTypes.Format, <tsp.FormatRequestArgs>{
             file: path,
             line: 1,

--- a/src/tsp-client.ts
+++ b/src/tsp-client.ts
@@ -79,6 +79,7 @@ export class TspClient {
         this.sendMessage(command, true, args);
     }
 
+    request(command: CommandTypes.Configure, args: protocol.ConfigureRequestArguments): Promise<protocol.ConfigureResponse>
     request(command: CommandTypes.Definition, args: protocol.FileLocationRequestArgs): Promise<protocol.DefinitionResponse>
     request(command: CommandTypes.Format, args: protocol.FormatRequestArgs): Promise<protocol.FormatResponse>
     request(command: CommandTypes.GetApplicableRefactors, args: protocol.CodeFixRequestArgs): Promise<protocol.GetCodeFixesResponse>


### PR DESCRIPTION
Pull request regarding issue: https://github.com/theia-ide/typescript-language-server/issues/41

According to [1], it seems Microsoft is not planning on supporting formatting configuration on "format".

This PR provides a basic way to support tsfmt.json via the configure command.

We're currently working on our fork, to support the options provided by the textDocument/formatting request from the language server protocol.

Hope this is helpful. If there are any things we need to fix, please let us know.

[1] https://github.com/Microsoft/TypeScript/pull/2468#issuecomment-86085433