### PR TITLE
Document formatting support editor options

### DIFF
--- a/src/lsp-server.spec.ts
+++ b/src/lsp-server.spec.ts
@@ -172,6 +172,48 @@ describe('formatting', () => {
     const result = applyEdits(doc.text, edits);
     assert.equal('export function foo(): void { }', result);
   }).timeout(10000);
+
+  it('indent settings (3 spaces)', async () => {
+    const doc = {
+      uri: uri('bar.ts'),
+      languageId: 'typescript',
+      version: 1,
+      text: 'function foo() {\n// some code\n}'
+    }
+    server.didOpenTextDocument({
+      textDocument: doc
+    })
+    const edits = await server.documentFormatting({
+      textDocument: doc,
+      options: {
+        tabSize: 3,
+        insertSpaces: true
+      }
+    })
+    const result = applyEdits(doc.text, edits);
+    assert.equal('function foo() {\n   // some code\n}', result);
+  }).timeout(10000);
+
+  it('indent settings (tabs)', async () => {
+    const doc = {
+      uri: uri('bar.ts'),
+      languageId: 'typescript',
+      version: 1,
+      text: 'function foo() {\n// some code\n}'
+    }
+    server.didOpenTextDocument({
+      textDocument: doc
+    })
+    const edits = await server.documentFormatting({
+      textDocument: doc,
+      options: {
+        tabSize: 4,
+        insertSpaces: false
+      }
+    })
+    const result = applyEdits(doc.text, edits);
+    assert.equal('function foo() {\n\t// some code\n}', result);
+  }).timeout(10000);
 });
 
 

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -420,10 +420,15 @@ export class LspServer {
         let opts = <tsp.FormatCodeSettings>{
             ...params.options
         }
+
         // translate
-        if (!opts.convertTabsToSpaces) {
+        if (opts.convertTabsToSpaces === undefined) {
             opts.convertTabsToSpaces = params.options.insertSpaces
         }
+        if (opts.indentSize === undefined) {
+            opts.indentSize = params.options.tabSize
+        }
+
         try {
             opts = JSON.parse(fs.readFileSync(this.rootPath() + "/tsfmt.json", 'utf-8'));
         } catch (err) {


### PR DESCRIPTION
The promised PR to convert the language server protocol's `FormattingOptions` (`tabSize` and `insertSpaces`) to the tsserver protocol's `FormatCodeSettings` (`indentSize` and `convertTabsToSpaces`).

Should address issue https://github.com/theia-ide/typescript-language-server/issues/10, to a degree, and fully satisfies the original motivation behind issue https://github.com/theia-ide/typescript-language-server/issues/41.