### PR TITLE
fix travis caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ cache:
   yarn: true
   directories:
   - node_modules
+  - example/node_modules
+  - server/node_modules
 branches:
   only:
   - master


### PR DESCRIPTION
all node_modules should be cached with yarn workspaces, otherwise yarn redownloads everything