### PR TITLE
Publish diagnostics for all open files when multiple files are open

### DIFF
--- a/server/src/diagnostic-queue.ts
+++ b/server/src/diagnostic-queue.ts
@@ -14,19 +14,19 @@ import debounce = require('p-debounce');
 
 class FileDiagnostics {
     private readonly diagnosticsPerKind = new Map<EventTypes, lsp.Diagnostic[]>();
-    
+
     constructor(readonly uri: string) { }
-    
+
     private readonly returnDiagnostics = debounce((resolve: (params: lsp.PublishDiagnosticsParams) => void) => {
         const diagnostics = this.getDiagnostics();
         resolve({ uri: this.uri, diagnostics });
     }, 50);
-    
+
     public updateDiagnostics(kind: EventTypes, diagnostics: tsp.Diagnostic[]): Promise<lsp.PublishDiagnosticsParams> {
         this.diagnosticsPerKind.set(kind, diagnostics.map(toDiagnostic));
         return new Promise((resolve) => this.returnDiagnostics(resolve));
     }
-    
+
     protected getDiagnostics(): lsp.Diagnostic[] {
         const result: lsp.Diagnostic[] = [];
         for (const value of this.diagnosticsPerKind.values()) {

--- a/server/src/lsp-server.spec.ts
+++ b/server/src/lsp-server.spec.ts
@@ -73,7 +73,7 @@ describe('diagnostics', () => {
         server.didOpenTextDocument({
             textDocument: doc
         })
-        
+
         server.requestDiagnostics();
         await server.requestDiagnostics();
         await new Promise(resolve => setTimeout(resolve, 200));
@@ -83,7 +83,7 @@ describe('diagnostics', () => {
         assert.equal(fileDiagnostics.length, 1);
         assert.equal("Cannot find name 'unknown'.", fileDiagnostics[0].message);
     }).timeout(10000);
-    
+
     it('multiple files test', async () => {
         const doc = {
             uri: uri('multipleFileDiagnosticsBar.ts'),
@@ -111,7 +111,7 @@ describe('diagnostics', () => {
         server.didOpenTextDocument({
             textDocument: doc2
         })
-        
+
         await server.requestDiagnostics();
         await new Promise(resolve => setTimeout(resolve, 200));
         const diagnosticsForThisTest = diagnostics.filter(d => d!.uri === doc.uri || d!.uri === doc2.uri);

--- a/server/src/lsp-server.spec.ts
+++ b/server/src/lsp-server.spec.ts
@@ -13,17 +13,18 @@ import { TextDocument } from 'vscode-languageserver';
 
 const assert = chai.assert;
 
-let diagnostics: lsp.PublishDiagnosticsParams | undefined;
+let diagnostics: Array<lsp.PublishDiagnosticsParams | undefined>;
 
 let server: LspServer;
 
 before(async () => {
     server = await createServer({
         rootUri: null,
-        publishDiagnostics: args => diagnostics = args
+        publishDiagnostics: args => diagnostics.push(args)
     })
 });
 beforeEach(() => {
+    diagnostics = [];
     server.closeAll();
 })
 
@@ -60,7 +61,7 @@ describe('completion', () => {
 describe('diagnostics', () => {
     it('simple test', async () => {
         const doc = {
-            uri: uri('bar.ts'),
+            uri: uri('diagnosticsBar.ts'),
             languageId: 'typescript',
             version: 1,
             text: `
@@ -72,12 +73,50 @@ describe('diagnostics', () => {
         server.didOpenTextDocument({
             textDocument: doc
         })
-        await server.requestDiagnostics();
+        
+        server.requestDiagnostics();
         await server.requestDiagnostics();
         await new Promise(resolve => setTimeout(resolve, 200));
-        const diags = diagnostics!.diagnostics;
-        assert.equal(1, diags.length);
-        assert.equal("Cannot find name 'unknown'.", diags[0].message);
+        const diagnosticsForThisFile = diagnostics.filter(d => d!.uri === doc.uri);
+        assert.equal(diagnosticsForThisFile.length, 1, JSON.stringify(diagnostics));
+        const fileDiagnostics = diagnosticsForThisFile[0]!.diagnostics;
+        assert.equal(fileDiagnostics.length, 1);
+        assert.equal("Cannot find name 'unknown'.", fileDiagnostics[0].message);
+    }).timeout(10000);
+    
+    it('multiple files test', async () => {
+        const doc = {
+            uri: uri('multipleFileDiagnosticsBar.ts'),
+            languageId: 'typescript',
+            version: 1,
+            text: `
+    export function bar(): void {
+        unknown('test')
+    }
+`
+        }
+        const doc2 = {
+            uri: uri('multipleFileDiagnosticsFoo.ts'),
+            languageId: 'typescript',
+            version: 1,
+            text: `
+    export function foo(): void {
+        unknown('test')
+    }
+`
+        }
+        server.didOpenTextDocument({
+            textDocument: doc
+        })
+        server.didOpenTextDocument({
+            textDocument: doc2
+        })
+        
+        await server.requestDiagnostics();
+        await new Promise(resolve => setTimeout(resolve, 200));
+        const diagnosticsForThisTest = diagnostics.filter(d => d!.uri === doc.uri || d!.uri === doc2.uri);
+        await new Promise(resolve => setTimeout(resolve, 200));
+        assert.equal(diagnosticsForThisTest.length, 2, JSON.stringify(diagnostics));
     }).timeout(10000);
 });
 
@@ -125,7 +164,7 @@ function symbolsAsString(symbols: (lsp.DocumentSymbol | lsp.SymbolInformation)[]
 describe('editing', () => {
     it('open and change', async () => {
         const doc = {
-            uri: uri('bar.ts'),
+            uri: uri('openAndChangeBar.ts'),
             languageId: 'typescript',
             version: 1,
             text: `
@@ -151,9 +190,9 @@ describe('editing', () => {
         await server.requestDiagnostics()
         await server.requestDiagnostics()
         await new Promise(resolve => setTimeout(resolve, 200));
-        const diags = diagnostics!.diagnostics;
-        assert.isTrue(diags.length >= 1, diags.map(d => d.message).join(','));
-        assert.equal("Cannot find name 'unknown'.", diags[0].message);
+        const fileDiagnostics = diagnostics.filter(d => d!.uri === doc.uri)[0]!.diagnostics;
+        assert.isTrue(fileDiagnostics.length >= 1, fileDiagnostics.map(d => d.message).join(','));
+        assert.equal("Cannot find name 'unknown'.", fileDiagnostics[0].message);
     }).timeout(10000);
 });
 


### PR DESCRIPTION
### Notes
- We now create a `debounce` function per open file, so two different files will not 'bounce' the diagnostics for one another.
- I had to use test specific uri's in the tests to prevent the tests from interacting. Even though the tests run in series, they re-use some state (the LSP server) which will causes the tests to interact. Not re-using the state is, I think, not an option because it will slow down the tests.

### Testing
- Ran the tests
- Tested against an IDE. This CR resolves [this issue](https://github.com/theia-ide/typescript-language-server/issues/70)