### PR TITLE
respect URIs received from clients

### DIFF
--- a/server/src/quickfix.ts
+++ b/server/src/quickfix.ts
@@ -9,8 +9,9 @@ import * as lsp from 'vscode-languageserver';
 import * as tsp from 'typescript/lib/protocol';
 import { Commands } from './commands';
 import { toTextDocumentEdit } from './protocol-translation';
+import { LspDocuments } from './document';
 
-export function provideQuickFix(response: tsp.GetCodeFixesResponse | undefined, result: (lsp.Command | lsp.CodeAction)[]): void {
+export function provideQuickFix(response: tsp.GetCodeFixesResponse | undefined, result: (lsp.Command | lsp.CodeAction)[], documents: LspDocuments | undefined): void {
     if (!response || !response.body) {
         return;
     }
@@ -19,7 +20,7 @@ export function provideQuickFix(response: tsp.GetCodeFixesResponse | undefined, 
             title: fix.description,
             command: Commands.APPLY_WORKSPACE_EDIT,
             arguments: [<lsp.WorkspaceEdit>{
-                documentChanges: fix.changes.map(c => toTextDocumentEdit(c))
+                documentChanges: fix.changes.map(c => toTextDocumentEdit(c, documents))
             }]
         })
     }

--- a/server/src/test-utils.ts
+++ b/server/src/test-utils.ts
@@ -14,7 +14,7 @@ import { ConsoleLogger } from './logger';
 
 export function uri(suffix: string = ''): string {
     const resolved = this.filePath(suffix);
-    return pathToUri(resolved);
+    return pathToUri(resolved, undefined);
 }
 
 export function filePath(suffix: string = ''): string {


### PR DESCRIPTION
This PR makes sure that a server only normalizes URIs for internal computation, but sends responses and notification with client URIs.

It's motivated by https://github.com/atom/ide-typescript/issues/127#issuecomment-421991658