### PR TITLE
Add Documentation for TSServer Log Verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ typescript-language-server --stdio
     --log-level <log-level>                A number indicating the log level (4 = log, 3 = info, 2 = warn, 1 = error). Defaults to `3`.
     --socket <port>                        use socket. example: --socket=5000
     --tsserver-log-file <tsServerLogFile>  Specify a tsserver log file. example: --tsserver-log-file=ts-logs.txt
+    --tsserver-log-verbosity <verbosity>   Specify tsserver log verbosity (terse, normal, verbose). Defaults to `normal`. example: --tsserver-log-verbosity=verbose
     --tsserver-path <path>                 Specify path to tsserver. example: --tsserver-path=tsserver
     -h, --help                             output usage information
 ```

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -18,13 +18,18 @@ const program = new Command('typescript-language-server')
     .option('--log-level <logLevel>', 'A number indicating the log level (4 = log, 3 = info, 2 = warn, 1 = error). Defaults to `2`.')
     .option('--socket <port>', 'use socket. example: --socket=5000')
     .option('--tsserver-log-file <tsserverLogFile>', 'Specify a tsserver log file. example: --tsserver-log-file ts-logs.txt')
-    .option('--tsserver-log-verbosity <tsserverLogVerbosity>', 'Specify a tsserver log verbosity (terse, normal, verbose). example: --tsserver-log-verbosity verbose')
+    .option('--tsserver-log-verbosity <tsserverLogVerbosity>', 'Specify a tsserver log verbosity (terse, normal, verbose). Defaults to `normal`.' +
+      ' example: --tsserver-log-verbosity verbose')
     .option('--tsserver-path <path>', `Specify path to tsserver. example: --tsserver-path=${getTsserverExecutable()}`)
     .parse(process.argv);
 
 if (!(program.stdio || program.socket || program.nodeIpc)) {
     console.error('Connection type required (stdio, node-ipc, socket). Refer to --help for more details.');
     process.exit(1);
+}
+
+if (program.tsserverLogFile && !program.tsserverLogVerbosity) {
+  program.tsserverLogVerbosity = 'normal'
 }
 
 let logLevel = lsp.MessageType.Warning


### PR DESCRIPTION
Also fixes ignoring tsserver logging to file if verbosity was not set.

This was especially confusing since verbosity was not documented. Now a default  of `normal` will be used if verbosity is not set and tsserver logging to file is.