### PR TITLE
[calls] Initial implementation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,11 +11,15 @@
                     "spec",
                     "--require",
                     "source-map-support/register",
-                    "--compilers",
-                    "ts:ts-node/register",
+                    "--require",
+                    "ts-node/register",
                     "--no-timeouts",
                     "${file}"
                 ],
+                "env": {
+                    "TS_NODE_PROJECT": "${workspaceRoot}/server/tsconfig.json",
+                    "PATH": "${workspaceRoot}/node_modules/.bin/:${env:PATH}"
+                },
                 "internalConsoleOptions": "openOnSessionStart"
             }
         ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ typescript-language-server --stdio
     -V, --version                          output the version number
     --stdio                                use stdio
     --node-ipc                             use node-ipc
-    --log-level <log-level>                A number indicating the log level (4 = log, 3 = info, 2 = warn, 1 = error). Defaults to `3`.
+    --log-level <log-level>                A number indicating the log level (4 = log, 3 = info, 2 = warn, 1 = error). Defaults to `2`.
     --socket <port>                        use socket. example: --socket=5000
     --tsserver-log-file <tsServerLogFile>  Specify a tsserver log file. example: --tsserver-log-file=ts-logs.txt
     --tsserver-path <path>                 Specify path to tsserver. example: --tsserver-path=tsserver

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "mocha": "5.2.0",
         "rimraf": "^2.6.2",
         "source-map-support": "^0.4.18",
-        "ts-node": "<7.0.0",
+        "ts-node": "7.0.1",
         "tslint": "^5.11.0",
         "tslint-language-service": "^0.9.9",
         "typescript": "^3.0.1"

--- a/server/src/calls.ts
+++ b/server/src/calls.ts
@@ -1,0 +1,205 @@
+
+import * as tsp from 'typescript/lib/protocol';
+import * as lsp from 'vscode-languageserver';
+import * as lspcalls from './lsp-protocol.calls.proposed';
+import { TspClient } from './tsp-client';
+import { CommandTypes } from './tsp-command-types';
+import { uriToPath, toLocation, asRange, Range, toSymbolKind, pathToUri } from './protocol-translation';
+
+export async function computeCallers(tspClient: TspClient, args: lsp.TextDocumentPositionParams): Promise<lspcalls.CallsResult> {
+    const nullResult = { calls: [] };
+    const contextDefinition = await getDefinition(tspClient, args);
+    if (!contextDefinition) {
+        return nullResult;
+    }
+    const contextSymbol = await findEnclosingSymbol(tspClient, contextDefinition);
+    if (!contextSymbol) {
+        return nullResult;
+    }
+    const callerReferences = await findNonDefinitionReferences(tspClient, contextDefinition);
+    const calls: lspcalls.Call[] = [];
+    for (const callerReference of callerReferences) {
+        const symbol = await findEnclosingSymbol(tspClient, callerReference);
+        if (!symbol) {
+            continue;
+        }
+        const location = toLocation(callerReference, undefined);
+        calls.push({
+            location,
+            symbol
+        });
+    }
+    return { calls, symbol: contextSymbol };
+}
+export type DocumentProvider = (file: string) => lsp.TextDocument | undefined;
+export async function computeCallees(tspClient: TspClient, args: lsp.TextDocumentPositionParams, documentProvider: DocumentProvider): Promise<lspcalls.CallsResult> {
+    const nullResult = { calls: [] };
+    const contextDefinition = await getDefinition(tspClient, args);
+    if (!contextDefinition) {
+        return nullResult;
+    }
+    const contextSymbol = await findEnclosingSymbol(tspClient, contextDefinition);
+    if (!contextSymbol) {
+        return nullResult;
+    }
+    const outgoingCallReferences = await findOutgoingCalls(tspClient, contextSymbol, documentProvider);
+    const calls: lspcalls.Call[] = [];
+    for (const reference of outgoingCallReferences) {
+        const definitionReferences = await findDefinitionReferences(tspClient, reference);
+        const definitionReference = definitionReferences[0];
+        if (!definitionReference) {
+            continue;
+        }
+        const definitionSymbol = await findEnclosingSymbol(tspClient, definitionReference);
+        if (!definitionSymbol) {
+            continue;
+        }
+        const location = toLocation(reference, undefined);
+        calls.push({
+            location,
+            symbol: definitionSymbol
+        });
+    }
+    return { calls, symbol: contextSymbol };
+}
+
+async function findOutgoingCalls(tspClient: TspClient, contextSymbol: lspcalls.DefinitionSymbol, documentProvider: DocumentProvider): Promise<tsp.FileSpan[]> {
+
+    /**
+     * The TSP does not provide call references.
+     * As long as we are not able to access the AST in a tsserver plugin and return the information necessary as metadata to the reponse,
+     * we need to test possible calls.
+     */
+    const computeCallCandidates = (document: lsp.TextDocument, range: lsp.Range): lsp.Range[] => {
+        const symbolText = document.getText(range);
+        const regex = /\W([$_a-zA-Z0-9\u{00C0}-\u{E007F}]+)(<.*>)?\(/gmu; // Example: matches `candidate` in " candidate()", "Foo.candidate<T>()", etc.
+        let match = regex.exec(symbolText);
+        const candidates: { identifier: string; start: number; end: number; }[] = []
+        while (match) {
+            const identifier = match[1];
+            if (identifier) {
+                const start = match.index + match[0].indexOf(identifier);
+                const end = start + identifier.length;
+                candidates.push({ identifier, start, end });
+            }
+            match = regex.exec(symbolText);
+        }
+        const offset = document.offsetAt(range.start);
+        const candidateRanges = candidates.map(c => lsp.Range.create(document.positionAt(offset + c.start), document.positionAt(offset + c.end)));
+        return candidateRanges;
+    }
+
+    /**
+     * This function tests a candidate and returns a locaion for a valid call.
+     */
+    const validateCall = async (file: string, candidateRange: lsp.Range): Promise<tsp.FileSpan | undefined> => {
+        const tspPosition = { line: candidateRange.start.line + 1, offset: candidateRange.start.character + 1 };
+        const references = await findNonDefinitionReferences(tspClient, { file, start: tspPosition, end: tspPosition });
+        for (const reference of references) {
+        const tspPosition = { line: candidateRange.start.line + 1, offset: candidateRange.start.character + 1 };
+            if (tspPosition.line === reference.start.line) {
+                return reference;
+            }
+        }
+    }
+
+    const calls: tsp.FileSpan[] = [];
+    const file = uriToPath(contextSymbol.location.uri)!;
+    const document = documentProvider(file);
+    if (!document) {
+        return calls;
+    }
+    const candidateRanges = computeCallCandidates(document, contextSymbol.location.range);
+    for (const candidateRange of candidateRanges) {
+        const call = await validateCall(file, candidateRange);
+        if (call) {
+            calls.push(call);
+        }
+    }
+    return calls;
+}
+
+async function getDefinition(tspClient: TspClient, args: lsp.TextDocumentPositionParams): Promise<tsp.FileSpan | undefined> {
+    const file = uriToPath(args.textDocument.uri);
+    if (!file) {
+        return undefined;
+    }
+    const definitionResult = await tspClient.request(CommandTypes.Definition, {
+        file,
+        line: args.position.line + 1,
+        offset: args.position.character + 1
+    });
+    return definitionResult.body ? definitionResult.body[0] : undefined;
+}
+
+async function findEnclosingSymbol(tspClient: TspClient, args: tsp.FileSpan): Promise<lspcalls.DefinitionSymbol | undefined> {
+    const file = args.file;
+    const response = await tspClient.request(CommandTypes.NavTree, { file });
+    const tree = response.body;
+    if (!tree || !tree.childItems) {
+        return undefined;
+    }
+    const pos = lsp.Position.create(args.start.line - 1, args.start.offset - 1);
+    const symbol = await findEnclosingSymbolInTree(tree, lsp.Range.create(pos, pos));
+    if (!symbol) {
+        return undefined;
+    }
+    const uri = pathToUri(file, undefined);
+    return lspcalls.DefinitionSymbol.create(uri, symbol);
+}
+
+async function findEnclosingSymbolInTree(parent: tsp.NavigationTree, range: lsp.Range): Promise<lsp.DocumentSymbol | undefined> {
+    const inSpan = (span: tsp.TextSpan) => !!Range.intersection(asRange(span), range);
+    const inTree = (tree: tsp.NavigationTree) => tree.spans.some(span => inSpan(span));
+
+    let candidate = inTree(parent) ? parent : undefined;
+    outer: while (candidate) {
+        const children = candidate.childItems || [];
+        for (const child of children) {
+            if (inTree(child)) {
+                candidate = child;
+                continue outer;
+            }
+        }
+        break;
+    }
+    if (!candidate) {
+        return undefined;
+    }
+    const span = candidate.spans.find(span => inSpan(span))!;
+    const spanRange = asRange(span);
+    let selectionRange = spanRange;
+    if (candidate.nameSpan) {
+        const nameRange = asRange(candidate.nameSpan);
+        if (Range.intersection(spanRange, nameRange)) {
+            selectionRange = nameRange;
+        }
+    }
+    return {
+        name: candidate.text,
+        kind: toSymbolKind(candidate.kind),
+        range: spanRange,
+        selectionRange: selectionRange
+    }
+}
+
+async function findDefinitionReferences(tspClient: TspClient, args: tsp.FileSpan): Promise<tsp.FileSpan[]> {
+    return (await findReferences(tspClient, args)).filter(ref => ref.isDefinition);
+}
+
+async function findNonDefinitionReferences(tspClient: TspClient, args: tsp.FileSpan): Promise<tsp.FileSpan[]> {
+    return (await findReferences(tspClient, args)).filter(ref => !ref.isDefinition);
+}
+
+async function findReferences(tspClient: TspClient, args: tsp.FileSpan): Promise<tsp.ReferencesResponseItem[]> {
+    const file = args.file;
+    const result = await tspClient.request(CommandTypes.References, {
+        file,
+        line: args.start.line,
+        offset: args.start.offset
+    });
+    if (!result.body) {
+        return [];
+    }
+    return result.body.refs;
+}

--- a/server/src/lsp-connection.ts
+++ b/server/src/lsp-connection.ts
@@ -6,6 +6,7 @@
  */
 
 import * as lsp from 'vscode-languageserver';
+import * as lspcalls from './lsp-protocol.calls.proposed'
 
 import { Logger, LspClientLogger } from './logger';
 import { LspServer } from './lsp-server';
@@ -53,6 +54,9 @@ export function createLspConnection(options: IServerOptions): lsp.IConnection {
     connection.onSignatureHelp(server.signatureHelp.bind(server));
     connection.onWorkspaceSymbol(server.workspaceSymbol.bind(server));
     connection.onFoldingRanges(server.foldingRanges.bind(server));
+
+    // proposed `textDocument/calls` request
+    connection.onRequest(lspcalls.CallsRequest.type, server.calls.bind(server));
 
     return connection;
 }

--- a/server/src/lsp-protocol.calls.proposed.ts
+++ b/server/src/lsp-protocol.calls.proposed.ts
@@ -1,0 +1,138 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) TypeFox and others. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict';
+
+import { RequestType, RequestHandler } from 'vscode-jsonrpc';
+import { Location, SymbolKind, Range, DocumentSymbol } from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver';
+
+export interface CallsClientCapabilities {
+    /**
+     * The text document client capabilities
+     */
+    textDocument?: {
+        /**
+         * Capabilities specific to the `textDocument/calls`
+         */
+        calls?: {
+            /**
+             * Whether implementation supports dynamic registration. If this is set to `true`
+             * the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+             * return value for the corresponding server capability as well.
+             */
+            dynamicRegistration?: boolean;
+        };
+    }
+}
+
+export interface CallsServerCapabilities {
+    /**
+     * The server provides Call Hierarchy support.
+     */
+    callsProvider?: boolean | (lsp.TextDocumentRegistrationOptions & lsp.StaticRegistrationOptions);
+}
+
+/**
+ * A request to resolve all calls at a given text document position of a symbol definition or a call the same.
+ * The request's parameter is of type [CallsParams](#CallsParams), the response is of type [CallsResult](#CallsResult) or a
+ * Thenable that resolves to such.
+ */
+export namespace CallsRequest {
+    export const type = new RequestType<CallsParams, CallsResult, void, lsp.TextDocumentRegistrationOptions>('textDocument/calls');
+    export type HandlerSignature = RequestHandler<CallsParams, CallsResult | null, void>;
+}
+
+/**
+ * The parameters of a `textDocument/calls` request.
+ */
+export interface CallsParams extends lsp.TextDocumentPositionParams {
+    /**
+     * Outgoing direction for callees.
+     * The default is incoming for callers.
+     */
+    direction?: CallDirection;
+}
+
+/**
+ * Enum of call direction kinds
+ */
+export enum CallDirection {
+    /**
+     * Incoming calls aka. callers
+     */
+    Incoming = "incoming",
+    /**
+     * Outgoing calls aka. callees
+     */
+    Outgoing = "outgoing",
+}
+
+/**
+ * The result of a `textDocument/calls` request.
+ */
+export interface CallsResult {
+    /**
+     * The symbol of a definition for which the request was made.
+     *
+     * If no definition is found at a given text document position, the symbol is undefined.
+     */
+    symbol?: DefinitionSymbol;
+    /**
+     * List of calls.
+     */
+    calls: Call[];
+}
+
+/**
+ * Represents a directed call.
+ *
+ *
+ */
+export interface Call {
+    /**
+     * Actual location of a call to a definition.
+     */
+    location: Location;
+    /**
+     * Symbol refered to by this call. For outgoing calls this is a callee,
+     * otherwise a caller.
+     */
+    symbol: DefinitionSymbol;
+}
+
+export interface DefinitionSymbol {
+    /**
+     * The name of this symbol.
+     */
+    name: string;
+    /**
+     * More detail for this symbol, e.g the signature of a function.
+     */
+    detail?: string;
+    /**
+     * The kind of this symbol.
+     */
+    kind: SymbolKind;
+    /**
+     * The range enclosing this symbol not including leading/trailing whitespace but everything else
+     * like comments. This information is typically used to determine if the the clients cursor is
+     * inside the symbol to reveal in the symbol in the UI.
+     */
+    location: Location;
+    /**
+     * The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.
+     * Must be contained by the the `range`.
+     */
+    selectionRange: Range;
+
+}
+
+export namespace DefinitionSymbol {
+    export function create(uri: string, symbol: DocumentSymbol): DefinitionSymbol {
+        const { name, detail, kind, range, selectionRange } = symbol;
+        const location = { uri, range };
+        return { name, detail, kind, location, selectionRange };
+    }
+}

--- a/server/src/lsp-server.ts
+++ b/server/src/lsp-server.ts
@@ -8,6 +8,7 @@
 import * as path from 'path';
 import * as tempy from 'tempy';
 import * as lsp from 'vscode-languageserver';
+import * as lspcalls from './lsp-protocol.calls.proposed';
 import * as tsp from 'typescript/lib/protocol';
 import * as fs from 'fs-extra';
 import * as commandExists from 'command-exists';
@@ -36,6 +37,7 @@ import { provideRefactors } from './refactor';
 import { provideOrganizeImports } from './organize-imports';
 import { TypeScriptInitializeParams, TypeScriptInitializationOptions, TypeScriptInitializeResult } from './ts-protocol';
 import { collectDocumentSymbols, collectSymbolInformations } from './document-symbol';
+import { computeCallers, computeCallees } from './calls';
 
 export interface IServerOptions {
     logger: Logger
@@ -161,7 +163,7 @@ export class LspServer {
             },
             logFileUri
         };
-
+        (this.initializeResult.capabilities as lspcalls.CallsServerCapabilities).callsProvider = true;
         this.logger.log('onInitialize result', this.initializeResult);
         return this.initializeResult;
     }
@@ -868,5 +870,21 @@ export class LspServer {
                 "event": event.event
             });
         }
+    }
+
+    async calls(params: lspcalls.CallsParams): Promise<lspcalls.CallsResult> {
+        let callsResult = <lspcalls.CallsResult>{ calls: [] };
+        const file = uriToPath(params.textDocument.uri);
+        this.logger.log('calls', params, file);
+        if (!file) {
+            return callsResult;
+        }
+        if (params.direction === lspcalls.CallDirection.Outgoing) {
+            const documentProvider = (file: string) => this.documents.get(file);
+            callsResult = await computeCallees(this.tspClient, params, documentProvider);
+        } else {
+            callsResult = await computeCallers(this.tspClient, params);
+        }
+        return callsResult;
     }
 }

--- a/server/test-data/do.ts
+++ b/server/test-data/do.ts
@@ -1,0 +1,1 @@
+// though empty, this file is needed, otherwise tsserver is not able to work on this test resource

--- a/server/test-data/foo.ts
+++ b/server/test-data/foo.ts
@@ -1,0 +1,1 @@
+// though empty, this file is needed, otherwise tsserver is not able to work on this test resource

--- a/yarn.lock
+++ b/yarn.lock
@@ -5379,9 +5379,9 @@ trim-off-newlines@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
 
-ts-node@<7.0.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-6.2.0.tgz#65a0ae2acce319ea4fd7ac8d7c9f1f90c5da6baf"
+ts-node@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-7.0.1.tgz#9562dc2d1e6d248d24bc55f773e3f614337d9baf"
   dependencies:
     arrify "^1.0.0"
     buffer-from "^1.1.0"


### PR DESCRIPTION
This PR add the implementation for the proposed `textDocument/calls` request.

Protocol extension PR: https://github.com/Microsoft/vscode-languageserver-node/pull/420

LSP issue: https://github.com/Microsoft/language-server-protocol/issues/468