### PR TITLE
Allowing starting tsserver as a module using cp.fork

### DIFF
--- a/server/src/lsp-server.ts
+++ b/server/src/lsp-server.ts
@@ -75,7 +75,7 @@ export class LspServer {
             return this.options.tsserverPath;
         }
         // 1) look into node_modules of workspace root
-        let executable = findPathToModule(this.rootPath(), `.bin/${getTsserverExecutable()}`)
+        let executable = findPathToModule(this.rootPath(), `.bin/${getTsserverExecutable()}`);
         if (executable) {
             return executable;
         }
@@ -84,9 +84,9 @@ export class LspServer {
             return getTsserverExecutable();
         }
         // 3) look into node_modules of typescript-language-server
-        const bundled = findPathToModule(__dirname, `.bin/${getTsserverExecutable()}`);
+        const bundled = findPathToModule(__dirname, path.join("typescript", "lib", "tsserver.js"));
         if (!bundled) {
-            throw Error(`Couldn't find '${getTsserverExecutable()}' executable`)
+            throw Error(`Couldn't find '${getTsserverExecutable()}' executable or 'tsserver.js' module`)
         }
         return bundled;
     }

--- a/server/src/modules-resolver.ts
+++ b/server/src/modules-resolver.ts
@@ -18,7 +18,7 @@ export function findPathToModule(dir: string, moduleName: string): string|undefi
     }
     const parent = paths.resolve(dir, '..')
     if (parent !== dir) {
-        return findPathToModule(paths.resolve(dir, '..'), moduleName)
+        return findPathToModule(parent, moduleName)
     }
     return undefined
 }

--- a/server/src/tsp-client.spec.ts
+++ b/server/src/tsp-client.spec.ts
@@ -11,64 +11,77 @@ import { TspClient } from './tsp-client';
 import { ConsoleLogger } from './logger';
 import { filePath, readContents } from './test-utils';
 import { CommandTypes } from './tsp-command-types';
+import { findPathToModule } from './modules-resolver';
 
 const assert = chai.assert;
 
-const server = new TspClient({
+const executableServer = new TspClient({
   logger: new ConsoleLogger(),
   tsserverPath: 'tsserver'
 });
 
-server.start();
+const tsserverModuleRelativePath = path.join("typescript", "lib", "tsserver.js");
+const bundled = findPathToModule(__dirname, tsserverModuleRelativePath) as string;
+const moduleServer = new TspClient({
+  logger: new ConsoleLogger(),
+  tsserverPath: bundled
+});
 
-describe('ts server client', () => {
-  it('completion', () => {
-    const f = filePath('module2.ts')
-    server.notify(CommandTypes.Open, {
-      file: f,
-      fileContent: readContents(f)
-    });
-    return server.request(CommandTypes.Completions, {
-      file: f,
-      line: 1,
-      offset: 0,
-      prefix: 'im',
-      includeExternalModuleExports: true,
-      includeInsertTextCompletions: true
-    }).then(completions => {
-      assert.equal(completions.body![1].name, "ImageData");
-    });
-  }).timeout(5000);
+const servers = { executableServer, moduleServer };
+Object.keys(servers).forEach(serverName => {
+  const server = servers[serverName];
+  server.start();
 
-  it('references', () => {
-    const f = filePath('module2.ts')
-    server.notify(CommandTypes.Open, {
-      file: f,
-      fileContent: readContents(f)
-    });
-    return server.request(CommandTypes.References, {
-      file: f,
-      line: 8,
-      offset: 16
-    }).then(references => {
-      assert.equal(references.body!.symbolName, "doStuff");
-    });
-  }).timeout(5000);
+  describe('ts server client using ' + serverName, () => {
+    it('completion', () => {
+      const f = filePath('module2.ts')
+      server.notify(CommandTypes.Open, {
+        file: f,
+        fileContent: readContents(f)
+      });
+      return server.request(CommandTypes.Completions, {
+        file: f,
+        line: 1,
+        offset: 0,
+        prefix: 'im',
+        includeExternalModuleExports: true,
+        includeInsertTextCompletions: true
+      }).then(completions => {
+        assert.equal(completions.body![1].name, "ImageData");
+      });
+    }).timeout(5000);
 
-  it('documentHighlight', () => {
-    const f = filePath('module2.ts')
-    server.notify(CommandTypes.Open, {
-      file: f,
-      fileContent: readContents(f)
-    });
-    return server.request(CommandTypes.DocumentHighlights, {
-      file: f,
-      line: 8,
-      offset: 16,
-      filesToSearch: [f]
-    }).then(response => {
-      assert.isTrue(response.body!.some(({ file }) => file.endsWith('module2.ts')), JSON.stringify(response.body, undefined, 2));
-      assert.isFalse(response.body!.some(({ file }) => file.endsWith('module1.ts')), JSON.stringify(response.body, undefined, 2));
-    });
-  }).timeout(5000);
+    it('references', () => {
+      const f = filePath('module2.ts')
+      server.notify(CommandTypes.Open, {
+        file: f,
+        fileContent: readContents(f)
+      });
+      return server.request(CommandTypes.References, {
+        file: f,
+        line: 8,
+        offset: 16
+      }).then(references => {
+        assert.equal(references.body!.symbolName, "doStuff");
+      });
+    }).timeout(5000);
+
+    it('documentHighlight', () => {
+      const f = filePath('module2.ts')
+      server.notify(CommandTypes.Open, {
+        file: f,
+        fileContent: readContents(f)
+      });
+      return server.request(CommandTypes.DocumentHighlights, {
+        file: f,
+        line: 8,
+        offset: 16,
+        filesToSearch: [f]
+      }).then(response => {
+        assert.isTrue(response.body!.some(({ file }) => file.endsWith('module2.ts')), JSON.stringify(response.body, undefined, 2));
+        assert.isFalse(response.body!.some(({ file }) => file.endsWith('module1.ts')), JSON.stringify(response.body, undefined, 2));
+      });
+    }).timeout(5000);
+  });
+
 });

--- a/server/src/tsp-client.ts
+++ b/server/src/tsp-client.ts
@@ -86,7 +86,7 @@ export class TspClient {
             return;
         }
         const { tsserverPath, logFile, logVerbosity, globalPlugins, pluginProbeLocations } = this.options;
-        const args: string[] = []
+        const args: string[] = [];
         if (logFile) {
             args.push('--logFile', logFile);
         }
@@ -102,7 +102,10 @@ export class TspClient {
         this.cancellationPipeName = tempy.file({ name: 'tscancellation' } as any);
         args.push('--cancellationPipeName', this.cancellationPipeName + '*');
         this.logger.info(`Starting tsserver : '${tsserverPath} ${args.join(' ')}'`);
-        this.tsserverProc = cp.spawn(tsserverPath, args);
+        const tsserverPathIsModule = path.extname(tsserverPath) === ".js";
+        this.tsserverProc = tsserverPathIsModule
+            ? cp.fork(tsserverPath, args, { silent: true })
+            : cp.spawn(tsserverPath, args);
         this.readlineInterface = readline.createInterface(this.tsserverProc.stdout, this.tsserverProc.stdin, undefined);
         process.on('exit', () => {
             this.readlineInterface.close();


### PR DESCRIPTION
Previously, tsserver could only be started as an executable, which would often run the `.bin/tsserver` file that uses a Node shebang to start `tsserver.js` using the first Node on the `$PATH`.

With this PR, tsserver can also be started as a module, by setting `tsserverPath` so it points to `tsserver.js`. Also, when tsserver is bundled with the TS LSP server, it will be started using `cp.fork`, so it uses the same version of Node as the TS LSP server.

This PR is related to https://github.com/theia-ide/typescript-language-server/pull/78