### PR TITLE
Remove hardcoded request timeouts

### DIFF
--- a/server/src/tsp-client.ts
+++ b/server/src/tsp-client.ts
@@ -133,7 +133,7 @@ export class TspClient {
     ): Promise<TypeScriptRequestTypes[K][1]> {
         this.sendMessage(command, false, args);
         const seq = this.seq;
-        const request = (this.deferreds[seq] = new Deferred<any>(command)).promise;
+        const request = (this.deferreds[seq] = new Deferred<any>()).promise;
         if (token) {
             const onCancelled = token.onCancellationRequested(() => {
                 onCancelled.dispose();

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -9,26 +9,12 @@ import { clearTimeout } from "timers";
 
 export class Deferred<T> {
 
-    private timer: any
-
-    constructor(private operation: string, timeout?: number) {
-        this.timer = setTimeout(() => {
-            this.reject(new Error(this.operation + " timeout"));
-        }, timeout || 20000)
-    }
-
     resolve: (value?: T) => void;
     reject: (err?: any) => void;
 
     promise = new Promise<T>((resolve, reject) => {
-        this.resolve = obj => {
-            clearTimeout(this.timer);
-            resolve(obj);
-        }
-        this.reject = obj => {
-            clearTimeout(this.timer);
-            reject(obj);
-        }
+        this.resolve = resolve;
+        this.reject = reject;
     });
 }
 


### PR DESCRIPTION
Fixes #91 

I opted for removing the timeouts, because how much time a request should have to complete should really be determined by the client, and it should be possible to determine for each request or situation independently. And LSP already has a way to do this, which is `$/cancelRequest` - so when a request exceeded a timeout set by the client, the client can simply cancel the request.

I removed the functionality from `Deferred` since it is used no where else in the codebase but let me know if you would like me to keep it.