### PR TITLE
use https link for typefox.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Based on concepts and ideas from https://github.com/prabirshrestha/typescript-language-server.
 
-Maintained by [TypeFox](http://typefox.io) and others.
+Maintained by [TypeFox](https://typefox.io) and others.
 
 # Supported Protocol features
 


### PR DESCRIPTION
In the mean time you guys should really redirect all http urls to https and setup a linter to disallow insecure urls to be checked in. 😃  