### PR TITLE
Fix empty documentHighlight results due to inconsistent path delimiters

### DIFF
--- a/server/src/lsp-server.ts
+++ b/server/src/lsp-server.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017, 2018 TypeFox and others.
+ * Copyright (C) 2017 - 2019 TypeFox and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -758,7 +758,9 @@ export class LspServer {
         }
         const result: lsp.DocumentHighlight[] = [];
         for (const item of response.body) {
-            if (item.file === file) {
+            // tsp returns item.file with POSIX path delimiters, whereas file is platform specific.
+            // Normalizing both ensures that the comparison is consistent.
+            if (path.normalize(item.file) === path.normalize(file)) {
                 const highlights = toDocumentHighlight(item);
                 result.push(...highlights)
             }

--- a/server/src/lsp-server.ts
+++ b/server/src/lsp-server.ts
@@ -757,10 +757,11 @@ export class LspServer {
             return []
         }
         const result: lsp.DocumentHighlight[] = [];
+        const normalizedFile = path.normalize(file);
         for (const item of response.body) {
             // tsp returns item.file with POSIX path delimiters, whereas file is platform specific.
             // Normalizing both ensures that the comparison is consistent.
-            if (path.normalize(item.file) === path.normalize(file)) {
+            if (path.normalize(item.file) === normalizedFile) {
                 const highlights = toDocumentHighlight(item);
                 result.push(...highlights)
             }

--- a/server/src/lsp-server.ts
+++ b/server/src/lsp-server.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 - 2019 TypeFox and others.
+ * Copyright (C) 2017, 2018 TypeFox and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -757,11 +757,10 @@ export class LspServer {
             return []
         }
         const result: lsp.DocumentHighlight[] = [];
-        const normalizedFile = path.normalize(file);
         for (const item of response.body) {
             // tsp returns item.file with POSIX path delimiters, whereas file is platform specific.
-            // Normalizing both ensures that the comparison is consistent.
-            if (path.normalize(item.file) === normalizedFile) {
+            // Converting to a URI and back to a path ensures consistency.
+            if (uriToPath(pathToUri(item.file, this.documents)) === file) {
                 const highlights = toDocumentHighlight(item);
                 result.push(...highlights)
             }


### PR DESCRIPTION
Closes #94.

I did not provide any additional unit tests as the only realistic setup to reproduce this issue would be when running the test suite on a Windows machine, which is impractical. The change is small and well documented, it's probably not worth it anyway!

