### PR TITLE
Call compilerOptionsForInferredProjects during initialization

### DIFF
--- a/server/src/lsp-server.ts
+++ b/server/src/lsp-server.ts
@@ -128,6 +128,17 @@ export class LspServer {
             }
         });
 
+        this.tspClient.request(CommandTypes.CompilerOptionsForInferredProjects, {
+            options: {
+                module: tsp.ModuleKind.CommonJS,
+                target: tsp.ScriptTarget.ES2016,
+                jsx: tsp.JsxEmit.Preserve,
+                allowJs: true,
+                allowSyntheticDefaultImports: true,
+                allowNonTsExtensions: true
+            }
+        });
+
         const logFileUri = logFile && pathToUri(logFile, undefined);
         this.initializeResult = {
             capabilities: {

--- a/server/src/tsp-client.ts
+++ b/server/src/tsp-client.ts
@@ -30,6 +30,7 @@ export interface TspClientOptions {
 
 interface TypeScriptRequestTypes {
     'geterr': [protocol.GeterrRequestArgs, any],
+    'compilerOptionsForInferredProjects': [protocol.SetCompilerOptionsForInferredProjectsArgs, protocol.SetCompilerOptionsForInferredProjectsResponse];
     'documentHighlights': [protocol.DocumentHighlightsRequestArgs, protocol.DocumentHighlightsResponse],
     'applyCodeActionCommand': [protocol.ApplyCodeActionCommandRequestArgs, protocol.ApplyCodeActionCommandResponse];
     'completionEntryDetails': [protocol.CompletionDetailsRequestArgs, protocol.CompletionDetailsResponse];


### PR DESCRIPTION
Fixes https://github.com/eclipse-theia/theia/issues/6720

In order to get better code intelligence for "inferred" projects,
tsserver supports a "compilerOptionsForInferredProjects" command that
informs the TypeScript compiler about how files should be compiled.

This mimicks what the VS Code client does just after calling
"configure" (https://github.com/microsoft/vscode/blob/58d954737facf9478a8255965e5d365bc3d70f71/extensions/typescript-language-features/src/typescriptServiceClient.ts#L479).

Example of better code completion when working on the React sample project (https://code.visualstudio.com/docs/nodejs/reactjs-tutorial):

**Before:**

<img width="558" alt="Screen Shot 2019-12-16 at 12 32 33 AM" src="https://user-images.githubusercontent.com/1573717/70871091-96e1e500-1f9b-11ea-880c-5f802e68330b.png">

**After:**

<img width="589" alt="Screen Shot 2019-12-16 at 12 29 01 AM" src="https://user-images.githubusercontent.com/1573717/70871095-a06b4d00-1f9b-11ea-9802-fa7f24209bd3.png">

