### PR TITLE
[WIP] Resolve completions within LspServer.completion()

### DIFF
--- a/server/src/completion.ts
+++ b/server/src/completion.ts
@@ -13,7 +13,8 @@ import { asRange, toTextEdit, asPlainText, asTagsDocumentation, asDocumentation 
 import { Commands } from './commands';
 
 export interface TSCompletionItem extends lsp.CompletionItem {
-    data: tsp.CompletionDetailsRequestArgs
+    data: tsp.CompletionDetailsRequestArgs;
+    hasAction?: true;
 }
 
 export function asCompletionItem(entry: import('typescript/lib/protocol').CompletionEntry, file: string, position: lsp.Position, document: LspDocument): TSCompletionItem {
@@ -22,6 +23,7 @@ export function asCompletionItem(entry: import('typescript/lib/protocol').Comple
         kind: asCompletionItemKind(entry.kind),
         sortText: entry.sortText,
         commitCharacters: asCommitCharacters(entry.kind),
+        hasAction: entry.hasAction,
         data: {
             file,
             line: position.line + 1,


### PR DESCRIPTION
This allows additionalTextEdits to be provided in the
textDocument/completion response while abiding by the guideline here:

https://github.com/microsoft/language-server-protocol/issues/924

I learned of this today via https://github.com/emacs-lsp/lsp-mode/issues/1713#issuecomment-635513017