### PR TITLE
Remove warnings from LSP completion results

### DIFF
--- a/server/src/lsp-server.ts
+++ b/server/src/lsp-server.ts
@@ -433,7 +433,9 @@ export class LspServer {
                 includeInsertTextCompletions: true
             }));
             const body = result.body || [];
-            return body.map(entry => asCompletionItem(entry, file, params.position, document));
+            return body
+                .filter(entry => entry.kind !== 'warning')
+                .map(entry => asCompletionItem(entry, file, params.position, document));
         } catch (error) {
             if (error.message === "No content available.") {
                 this.logger.info('No content was available for completion request');


### PR DESCRIPTION
LSP warnings don't appear to be actual completion results that are meaningful. This PR removes them from completion results