### PR TITLE
Ensure TSP request cancellation cancels timeout handling

### DIFF
--- a/server/src/tsp-client.ts
+++ b/server/src/tsp-client.ts
@@ -137,9 +137,12 @@ export class TspClient {
     ): Promise<TypeScriptRequestTypes[K][1]> {
         this.sendMessage(command, false, args);
         const seq = this.seq;
-        const request = (this.deferreds[seq] = new Deferred<any>(command)).promise;
+        const deferred = new Deferred<TypeScriptRequestTypes[K][1]>(command);
+        this.deferreds[seq] = deferred;
+        const request = deferred.promise;
         if (token) {
             const onCancelled = token.onCancellationRequested(() => {
+                deferred.cancel();
                 onCancelled.dispose();
                 if (this.cancellationPipeName) {
                     const requestCancellationPipeName = this.cancellationPipeName + seq;

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -9,7 +9,7 @@ import { clearTimeout } from "timers";
 
 export class Deferred<T> {
 
-    private timer: any
+    private timer: NodeJS.Timer
 
     constructor(private operation: string, timeout?: number) {
         this.timer = setTimeout(() => {
@@ -17,8 +17,13 @@ export class Deferred<T> {
         }, timeout || 20000)
     }
 
+    cancel() {
+        // ignore rejections due to timeouts
+        clearTimeout(this.timer);
+    }
+
     resolve: (value?: T) => void;
-    reject: (err?: any) => void;
+    reject: (err?: unknown) => void;
 
     promise = new Promise<T>((resolve, reject) => {
         this.resolve = obj => {
@@ -36,6 +41,6 @@ export function getTsserverExecutable(): string {
     return isWindows() ? 'tsserver.cmd' : 'tsserver'
 }
 
-export function isWindows(): boolean {
+function isWindows(): boolean {
     return /^win/.test(process.platform);
 }


### PR DESCRIPTION
I'm trying to investigate https://github.com/apexskier/nova-typescript/issues/91, and discovered a potential issue that this fixes. If a typescript server request times out _after_ being cancelled, I think the timeout can still cause an unhandled rejection. I haven't found a real reproduction, so this is purely theoretical.

This fixes that by adding a `cancel` method to the `Deferred` utility that clears the timeout timer.

I also added a few type-only improvements (removing an unused export and some `any`s).

This conflicts a bit with https://github.com/theia-ide/typescript-language-server/pull/92, and can be closed if that one is merged (closed by #92).