### PR TITLE
Remove hardcoded request timeouts

### DIFF
--- a/server/src/lsp-server.ts
+++ b/server/src/lsp-server.ts
@@ -234,7 +234,6 @@ export class LspServer {
     }
     protected cancelDiagnostics(): void {
         if (this.diagnosticsTokenSource) {
-            this.diagnosticsTokenSource.cancel();
             this.diagnosticsTokenSource = undefined;
         }
     }

--- a/server/src/tsp-client.ts
+++ b/server/src/tsp-client.ts
@@ -137,12 +137,11 @@ export class TspClient {
     ): Promise<TypeScriptRequestTypes[K][1]> {
         this.sendMessage(command, false, args);
         const seq = this.seq;
-        const deferred = new Deferred<TypeScriptRequestTypes[K][1]>(command);
+        const deferred = new Deferred<TypeScriptRequestTypes[K][1]>();
         this.deferreds[seq] = deferred;
         const request = deferred.promise;
         if (token) {
             const onCancelled = token.onCancellationRequested(() => {
-                deferred.cancel();
                 onCancelled.dispose();
                 if (this.cancellationPipeName) {
                     const requestCancellationPipeName = this.cancellationPipeName + seq;

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -9,31 +9,12 @@ import { clearTimeout } from "timers";
 
 export class Deferred<T> {
 
-    private timer: NodeJS.Timer
-
-    constructor(private operation: string, timeout?: number) {
-        this.timer = setTimeout(() => {
-            this.reject(new Error(this.operation + " timeout"));
-        }, timeout || 20000)
-    }
-
-    cancel() {
-        // ignore rejections due to timeouts
-        clearTimeout(this.timer);
-    }
-
     resolve: (value?: T) => void;
     reject: (err?: unknown) => void;
 
     promise = new Promise<T>((resolve, reject) => {
-        this.resolve = obj => {
-            clearTimeout(this.timer);
-            resolve(obj);
-        }
-        this.reject = obj => {
-            clearTimeout(this.timer);
-            reject(obj);
-        }
+        this.resolve = resolve;
+        this.reject = reject;
     });
 }
 


### PR DESCRIPTION
Removes timeouts from `Deferred`, because clients can choose to cancel long-running operations if they need to.

This is the same as #92 with merge conflicts resolved.