### PR TITLE
Forward user preferences in initialization options

### DIFF
--- a/server/src/lsp-server.ts
+++ b/server/src/lsp-server.ts
@@ -97,9 +97,10 @@ export class LspServer {
         this.logger.log('initialize', params);
         this.initializeParams = params;
 
-        const { logVerbosity, plugins }: TypeScriptInitializationOptions = {
+        const { logVerbosity, plugins, preferences }: TypeScriptInitializationOptions = {
             logVerbosity: this.options.tsserverLogVerbosity,
             plugins: [],
+            preferences: {},
             ...this.initializeParams.initializationOptions
         };
         const logFile = this.getLogFile(logVerbosity);
@@ -124,7 +125,8 @@ export class LspServer {
         this.tspClient.start();
         this.tspClient.request(CommandTypes.Configure, {
             preferences: {
-                allowTextChangesInNewFiles: true
+                allowTextChangesInNewFiles: true,
+                ...preferences
             }
         });
 

--- a/server/src/ts-protocol.ts
+++ b/server/src/ts-protocol.ts
@@ -9,6 +9,7 @@
  * **IMPORTANT** this module should not depend on `vscode-languageserver` only protocol and types
  */
 import * as lsp from 'vscode-languageserver-protocol';
+import { UserPreferences } from 'typescript/lib/protocol';
 
 export namespace TypeScriptRenameRequest {
     export const type = new lsp.RequestType<lsp.TextDocumentPositionParams, any, void, void>("_typescript.rename");
@@ -22,6 +23,7 @@ export interface TypeScriptPlugin {
 export interface TypeScriptInitializationOptions {
     logVerbosity?: string
     plugins: TypeScriptPlugin[]
+    preferences?: UserPreferences
 }
 
 export type TypeScriptInitializeParams = lsp.InitializeParams & {


### PR DESCRIPTION
This PR adds an optional `preferences` property to the initialization options that is forwarded through to the tsserver, allowing [user preferences](https://github.com/microsoft/TypeScript/blob/703c1bc69d37ea35d0ba7c58d7632e9ba97c5d94/src/server/protocol.ts#L3313) like `importModuleSpecifierPreference`  to be set.

* Based off of the implementation by @rmagatti and discussion in https://github.com/theia-ide/typescript-language-server/pull/207 🙌 
* Should  also address https://github.com/theia-ide/typescript-language-server/issues/143

---

Tested to work locally with neovim and lsp-config given this config:

```lua
nvim_lsp.tsserver.setup {
    init_options = {
      preferences = {
        importModuleSpecifierPreference = "relative"
      }
    }
}
```