### PR TITLE
Update internal Typescript dependency from 3.9.0 to 4.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "rimraf": "^3.0.2",
         "source-map-support": "^0.5.19",
         "ts-node": "7.0.1",
-        "typescript": "^3.9.0"
+        "typescript": "^4.3.4"
     },
     "scripts": {
         "prepare": "lerna run clean && yarn build && yarn bundle",

--- a/server/src/completion.ts
+++ b/server/src/completion.ts
@@ -163,10 +163,10 @@ function asCodeActions(details: tsp.CompletionEntryDetails, filepath: string): {
     // Also check if we still have to apply other workspace edits and commands
     // using a vscode command
     const additionalTextEdits: lsp.TextEdit[] = [];
-    let hasReaminingCommandsOrEdits = false;
+    let hasRemainingCommandsOrEdits = false;
     for (const tsAction of details.codeActions) {
         if (tsAction.commands) {
-            hasReaminingCommandsOrEdits = true;
+            hasRemainingCommandsOrEdits = true;
         }
 
         // Apply all edits in the current file using `additionalTextEdits`
@@ -177,14 +177,14 @@ function asCodeActions(details: tsp.CompletionEntryDetails, filepath: string): {
                         additionalTextEdits.push(toTextEdit(textChange));
                     }
                 } else {
-                    hasReaminingCommandsOrEdits = true;
+                    hasRemainingCommandsOrEdits = true;
                 }
             }
         }
     }
 
     let command: lsp.Command | undefined = undefined;
-    if (hasReaminingCommandsOrEdits) {
+    if (hasRemainingCommandsOrEdits) {
         // Create command that applies all edits not in the current file.
         command = {
             title: '',

--- a/server/src/completion.ts
+++ b/server/src/completion.ts
@@ -6,7 +6,7 @@
  */
 
 import * as lsp from 'vscode-languageserver';
-import tsp from 'typescript/lib/protocol';
+import type tsp from 'typescript/lib/protocol';
 import { LspDocument } from './document';
 import { ScriptElementKind } from './tsp-command-types';
 import { asRange, toTextEdit, asPlainText, asDocumentation } from './protocol-translation';
@@ -16,7 +16,7 @@ export interface TSCompletionItem extends lsp.CompletionItem {
     data: tsp.CompletionDetailsRequestArgs;
 }
 
-export function asCompletionItem(entry: import('typescript/lib/protocol').CompletionEntry, file: string, position: lsp.Position, document: LspDocument): TSCompletionItem {
+export function asCompletionItem(entry: tsp.CompletionEntry, file: string, position: lsp.Position, document: LspDocument): TSCompletionItem {
     const item: TSCompletionItem = {
         label: entry.name,
         kind: asCompletionItemKind(entry.kind),

--- a/server/src/completion.ts
+++ b/server/src/completion.ts
@@ -70,7 +70,7 @@ export function asCompletionItem(entry: tsp.CompletionEntry, file: string, posit
     return item;
 }
 
-export function asCompletionItemKind(kind: ScriptElementKind): lsp.CompletionItemKind {
+function asCompletionItemKind(kind: ScriptElementKind): lsp.CompletionItemKind {
     switch (kind) {
         case ScriptElementKind.primitiveType:
         case ScriptElementKind.keyword:
@@ -114,7 +114,7 @@ export function asCompletionItemKind(kind: ScriptElementKind): lsp.CompletionIte
     return lsp.CompletionItemKind.Property;
 }
 
-export function asCommitCharacters(kind: ScriptElementKind): string[] | undefined {
+function asCommitCharacters(kind: ScriptElementKind): string[] | undefined {
     const commitCharacters: string[] = [];
     switch (kind) {
         case ScriptElementKind.memberGetAccessorElement:
@@ -152,7 +152,7 @@ export function asResolvedCompletionItem(item: TSCompletionItem, details: tsp.Co
     return item;
 }
 
-export function asCodeActions(details: tsp.CompletionEntryDetails, filepath: string): {
+function asCodeActions(details: tsp.CompletionEntryDetails, filepath: string): {
     command?: lsp.Command; additionalTextEdits?: lsp.TextEdit[];
 } {
     if (!details.codeActions || !details.codeActions.length) {
@@ -203,7 +203,7 @@ export function asCodeActions(details: tsp.CompletionEntryDetails, filepath: str
     };
 }
 
-export function asDetail({ displayParts, source }: tsp.CompletionEntryDetails): string | undefined {
+function asDetail({ displayParts, source }: tsp.CompletionEntryDetails): string | undefined {
     const result: string[] = [];
     const importPath = asPlainText(source);
     if (importPath) {

--- a/server/src/completion.ts
+++ b/server/src/completion.ts
@@ -203,11 +203,11 @@ function asCodeActions(details: tsp.CompletionEntryDetails, filepath: string): {
     };
 }
 
-function asDetail({ displayParts, source }: tsp.CompletionEntryDetails): string | undefined {
+function asDetail({ displayParts, sourceDisplay, source: deprecatedSource }: tsp.CompletionEntryDetails): string | undefined {
     const result: string[] = [];
-    const importPath = asPlainText(source);
-    if (importPath) {
-        result.push(`Auto import from '${importPath}'`);
+    const source = sourceDisplay || deprecatedSource;
+    if (source) {
+        result.push(`Auto import from '${asPlainText(source)}'`);
     }
     const detail = asPlainText(displayParts);
     if (detail) {

--- a/server/src/document-symbol.ts
+++ b/server/src/document-symbol.ts
@@ -55,7 +55,7 @@ function collectDocumentSymbolsInRange(parent: tsp.NavigationTree, symbols: lsp.
     return shouldInclude;
 }
 
-export function collectSymbolInformations(uri: string, current: tsp.NavigationTree, symbols: lsp.SymbolInformation[], containerName?: string): boolean {
+export function collectSymbolInformation(uri: string, current: tsp.NavigationTree, symbols: lsp.SymbolInformation[], containerName?: string): boolean {
     let shouldInclude = shouldIncludeEntry(current);
     const name = current.text;
     for (const span of current.spans) {
@@ -64,7 +64,7 @@ export function collectSymbolInformations(uri: string, current: tsp.NavigationTr
         if (current.childItems) {
             for (const child of current.childItems) {
                 if (child.spans.some(span => !!Range.intersection(range, asRange(span)))) {
-                    const includedChild = collectSymbolInformations(uri, child, children, name);
+                    const includedChild = collectSymbolInformation(uri, child, children, name);
                     shouldInclude = shouldInclude || includedChild;
                 }
             }

--- a/server/src/hover.ts
+++ b/server/src/hover.ts
@@ -17,7 +17,7 @@ export function asSignatureHelp(info: tsp.SignatureHelpItems): lsp.SignatureHelp
     };
 }
 
-export function getActiveParameter(info: tsp.SignatureHelpItems): number {
+function getActiveParameter(info: tsp.SignatureHelpItems): number {
     const activeSignature = info.items[info.selectedItemIndex];
     if (activeSignature && activeSignature.isVariadic) {
         return Math.min(info.argumentIndex, activeSignature.parameters.length - 1);
@@ -25,7 +25,7 @@ export function getActiveParameter(info: tsp.SignatureHelpItems): number {
     return info.argumentIndex;
 }
 
-export function asSignatureInformation(item: tsp.SignatureHelpItem): lsp.SignatureInformation {
+function asSignatureInformation(item: tsp.SignatureHelpItem): lsp.SignatureInformation {
     const parameters = item.parameters.map(asParameterInformation);
     const signature: lsp.SignatureInformation = {
         label: asPlainText(item.prefixDisplayParts),
@@ -40,7 +40,7 @@ export function asSignatureInformation(item: tsp.SignatureHelpItem): lsp.Signatu
     return signature;
 }
 
-export function asParameterInformation(parameter: tsp.SignatureHelpParameter): lsp.ParameterInformation {
+function asParameterInformation(parameter: tsp.SignatureHelpParameter): lsp.ParameterInformation {
     return {
         label: asPlainText(parameter.displayParts),
         documentation: asDocumentation(parameter)

--- a/server/src/lsp-server.spec.ts
+++ b/server/src/lsp-server.spec.ts
@@ -489,62 +489,65 @@ describe('code actions', () => {
             }
         }))!;
 
-        assert.deepEqual(result, [
-            {
+        assert.strictEqual(result.length, 2);
+        const quickFixDiagnostic = result.find(diagnostic => diagnostic.kind === 'quickfix');
+        assert.isDefined(quickFixDiagnostic);
+        assert.deepEqual(quickFixDiagnostic, {
+            title: "Prefix 'bar' with an underscore",
+            command: {
                 title: "Prefix 'bar' with an underscore",
-                command: {
-                    title: "Prefix 'bar' with an underscore",
-                    command: '_typescript.applyWorkspaceEdit',
-                    arguments: [
-                        {
-                            documentChanges: [
-                                {
-                                    textDocument: {
-                                        uri: uri('bar.ts'),
-                                        version: 1
-                                    },
-                                    edits: [
-                                        {
-                                            range: {
-                                                start: {
-                                                    line: 1,
-                                                    character: 24
-                                                },
-                                                end: {
-                                                    line: 1,
-                                                    character: 27
-                                                }
+                command: '_typescript.applyWorkspaceEdit',
+                arguments: [
+                    {
+                        documentChanges: [
+                            {
+                                textDocument: {
+                                    uri: uri('bar.ts'),
+                                    version: 1
+                                },
+                                edits: [
+                                    {
+                                        range: {
+                                            start: {
+                                                line: 1,
+                                                character: 24
                                             },
-                                            newText: '_bar'
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                },
-                kind: 'quickfix'
+                                            end: {
+                                                line: 1,
+                                                character: 27
+                                            }
+                                        },
+                                        newText: '_bar'
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
             },
-            {
+            kind: 'quickfix'
+        });
+        const refactorDiagnostic = result.find(diagnostic => diagnostic.kind === 'refactor');
+        assert.isDefined(refactorDiagnostic);
+        assert.deepEqual(refactorDiagnostic, {
+            title: 'Convert parameters to destructured object',
+            command: {
                 title: 'Convert parameters to destructured object',
-                command: {
-                    title: 'Convert parameters to destructured object',
-                    command: '_typescript.applyRefactoring',
-                    arguments: [
-                        {
-                            file: filePath('bar.ts'),
-                            startLine: 2,
-                            startOffset: 26,
-                            endLine: 2,
-                            endOffset: 50,
-                            refactor: 'Convert parameters to destructured object',
-                            action: 'Convert parameters to destructured object'
-                        }
-                    ]
-                },
-                kind: 'refactor'
-            }
-        ]);
+                command: '_typescript.applyRefactoring',
+                arguments: [
+                    {
+                        file: filePath('bar.ts'),
+                        startLine: 2,
+                        startOffset: 26,
+                        endLine: 2,
+                        endOffset: 50,
+                        refactor: 'Convert parameters to destructured object',
+                        action: 'Convert parameters to destructured object'
+                    }
+                ]
+            },
+            kind: 'refactor'
+        });
     }).timeout(10000);
 
     it('can filter quickfix code actions filtered by only', async () => {

--- a/server/src/lsp-server.spec.ts
+++ b/server/src/lsp-server.spec.ts
@@ -491,106 +491,58 @@ describe('code actions', () => {
 
         assert.deepEqual(result, [
             {
+                title: "Prefix 'bar' with an underscore",
                 command: {
+                    title: "Prefix 'bar' with an underscore",
+                    command: '_typescript.applyWorkspaceEdit',
                     arguments: [
                         {
                             documentChanges: [
                                 {
+                                    textDocument: {
+                                        uri: 'file:///Users/cameronlittle/Developer/typescript-language-server/server/test-data/bar.ts',
+                                        version: 1
+                                    },
                                     edits: [
                                         {
-                                            newText: '',
                                             range: {
-                                                end: {
-                                                    character: 37,
-                                                    line: 1
-                                                },
                                                 start: {
-                                                    character: 24,
-                                                    line: 1
-                                                }
-                                            }
-                                        },
-                                        {
-                                            newText: '',
-                                            range: {
-                                                end: {
-                                                    character: 16,
-                                                    line: 2
+                                                    line: 1,
+                                                    character: 24
                                                 },
-                                                start: {
-                                                    character: 8,
-                                                    line: 2
+                                                end: {
+                                                    line: 1,
+                                                    character: 27
                                                 }
-                                            }
+                                            },
+                                            newText: '_bar'
                                         }
-                                    ],
-                                    textDocument: {
-                                        uri: uri('bar.ts'),
-                                        version: 1
-                                    }
+                                    ]
                                 }
                             ]
                         }
-                    ],
-                    command: '_typescript.applyWorkspaceEdit',
-                    title: "Remove unused declaration for: 'bar'"
+                    ]
                 },
-                kind: 'quickfix',
-                title: "Remove unused declaration for: 'bar'"
+                kind: 'quickfix'
             },
             {
+                title: 'Convert parameters to destructured object',
                 command: {
+                    title: 'Convert parameters to destructured object',
+                    command: '_typescript.applyRefactoring',
                     arguments: [
                         {
-                            documentChanges: [
-                                {
-                                    edits: [
-                                        {
-                                            newText: '_bar',
-                                            range: {
-                                                end: {
-                                                    character: 27,
-                                                    line: 1
-                                                },
-                                                start: {
-                                                    character: 24,
-                                                    line: 1
-                                                }
-                                            }
-                                        }
-                                    ],
-                                    textDocument: {
-                                        uri: uri('bar.ts'),
-                                        version: 1
-                                    }
-                                }
-                            ]
-                        }
-                    ],
-                    command: '_typescript.applyWorkspaceEdit',
-                    title: "Prefix 'bar' with an underscore"
-                },
-                kind: 'quickfix',
-                title: "Prefix 'bar' with an underscore"
-            },
-            {
-                command: {
-                    arguments: [
-                        {
-                            action: 'Convert parameters to destructured object',
+                            file: '/Users/cameronlittle/Developer/typescript-language-server/server/test-data/bar.ts',
+                            startLine: 2,
+                            startOffset: 26,
                             endLine: 2,
                             endOffset: 50,
-                            file: filePath('bar.ts'),
                             refactor: 'Convert parameters to destructured object',
-                            startLine: 2,
-                            startOffset: 26
+                            action: 'Convert parameters to destructured object'
                         }
-                    ],
-                    command: '_typescript.applyRefactoring',
-                    title: 'Convert parameters to destructured object'
+                    ]
                 },
-                kind: 'refactor',
-                title: 'Convert parameters to destructured object'
+                kind: 'refactor'
             }
         ]);
     }).timeout(10000);

--- a/server/src/lsp-server.spec.ts
+++ b/server/src/lsp-server.spec.ts
@@ -500,7 +500,7 @@ describe('code actions', () => {
                             documentChanges: [
                                 {
                                     textDocument: {
-                                        uri: 'file:///Users/cameronlittle/Developer/typescript-language-server/server/test-data/bar.ts',
+                                        uri: uri('bar.ts'),
                                         version: 1
                                     },
                                     edits: [
@@ -532,7 +532,7 @@ describe('code actions', () => {
                     command: '_typescript.applyRefactoring',
                     arguments: [
                         {
-                            file: '/Users/cameronlittle/Developer/typescript-language-server/server/test-data/bar.ts',
+                            file: filePath('bar.ts'),
                             startLine: 2,
                             startOffset: 26,
                             endLine: 2,

--- a/server/src/lsp-server.ts
+++ b/server/src/lsp-server.ts
@@ -24,7 +24,7 @@ import { findPathToModule } from './modules-resolver';
 import {
     toDocumentHighlight, asRange, asTagsDocumentation,
     uriToPath, toSymbolKind, toLocation, toPosition,
-    pathToUri, toTextEdit, toFileRangeRequestArgs
+    pathToUri, toTextEdit, toFileRangeRequestArgs, asPlainText
 } from './protocol-translation';
 import { getTsserverExecutable } from './utils';
 import { LspDocuments, LspDocument } from './document';
@@ -485,12 +485,7 @@ export class LspServer {
             { language: 'typescript', value: result.body.displayString }
         ];
         const tags = asTagsDocumentation(result.body.tags);
-        let documentation: string;
-        if (typeof result.body.documentation === 'string') {
-            documentation = result.body.documentation;
-        } else {
-            documentation = result.body.documentation?.map(p => p.text).join('') || '';
-        }
+        const documentation = asPlainText(result.body.documentation);
         contents.push(documentation + (tags ? '\n\n' + tags : ''));
         return {
             contents,

--- a/server/src/protocol-translation.ts
+++ b/server/src/protocol-translation.ts
@@ -188,9 +188,8 @@ export function asDocumentation(data: {
     tags?: tsp.JSDocTagInfo[];
 }): lsp.MarkupContent | undefined {
     let value = '';
-    const documentation = asPlainText(data.documentation);
-    if (documentation) {
-        value += documentation;
+    if (data.documentation) {
+        value += asPlainText(data.documentation);
     }
     if (data.tags) {
         const tagsDocumentation = asTagsDocumentation(data.tags);
@@ -211,11 +210,14 @@ export function asTagsDocumentation(tags: tsp.JSDocTagInfo[]): string {
 export function asTagDocumentation(tag: tsp.JSDocTagInfo): string {
     switch (tag.name) {
         case 'param': {
+            if (!tag.text) {
+                break;
+            }
             let text: string;
             if (typeof tag.text === 'string') {
                 text = tag.text;
             } else {
-                text = tag.text?.map(p => p.text).join('') || '';
+                text = asPlainText(tag.text);
             }
             const body = text.split(/^([\w.]+)\s*-?\s*/);
             if (body && body.length === 3) {
@@ -245,12 +247,7 @@ export function asTagBodyText(tag: tsp.JSDocTagInfo): string | undefined {
         return undefined;
     }
 
-    let text: string;
-    if (typeof tag.text === 'string') {
-        text = tag.text;
-    } else {
-        text = tag.text.map(p => p.text).join('');
-    }
+    const text = asPlainText(tag.text);
 
     switch (tag.name) {
         case 'example':
@@ -265,12 +262,9 @@ export function asTagBodyText(tag: tsp.JSDocTagInfo): string | undefined {
     return text;
 }
 
-export function asPlainText(parts: undefined): undefined;
-export function asPlainText(parts: tsp.SymbolDisplayPart[]): string;
-export function asPlainText(parts: tsp.SymbolDisplayPart[] | undefined): string | undefined;
-export function asPlainText(parts: tsp.SymbolDisplayPart[] | undefined): string | undefined {
-    if (!parts) {
-        return undefined;
+export function asPlainText(parts: string | tsp.SymbolDisplayPart[]): string {
+    if (typeof parts === 'string') {
+        return parts;
     }
     return parts.map(part => part.text).join('');
 }

--- a/server/src/protocol-translation.ts
+++ b/server/src/protocol-translation.ts
@@ -24,7 +24,7 @@ export function pathToUri(filepath: string, documents: LspDocuments | undefined)
     return document ? document.uri : fileUri.toString();
 }
 
-export function currentVersion(filepath: string, documents: LspDocuments | undefined): number {
+function currentVersion(filepath: string, documents: LspDocuments | undefined): number {
     const fileUri = URI.file(filepath);
     const document = documents && documents.get(fileUri.fsPath);
     return document ? document.version : 0;
@@ -87,7 +87,7 @@ export function toSymbolKind(tspKind: string): lsp.SymbolKind {
     return symbolKindsMapping[tspKind] || lsp.SymbolKind.Variable;
 }
 
-export function toDiagnosticSeverity(category: string): lsp.DiagnosticSeverity {
+function toDiagnosticSeverity(category: string): lsp.DiagnosticSeverity {
     switch (category) {
         case 'error': return lsp.DiagnosticSeverity.Error;
         case 'warning': return lsp.DiagnosticSeverity.Warning;
@@ -110,7 +110,7 @@ export function toDiagnostic(diagnostic: tsp.Diagnostic, documents: LspDocuments
     };
 }
 
-export function asRelatedInformation(info: tsp.DiagnosticRelatedInformation[] | undefined, documents: LspDocuments | undefined): lsp.DiagnosticRelatedInformation[] | undefined {
+function asRelatedInformation(info: tsp.DiagnosticRelatedInformation[] | undefined, documents: LspDocuments | undefined): lsp.DiagnosticRelatedInformation[] | undefined {
     if (!info) {
         return undefined;
     }
@@ -135,34 +135,6 @@ export function toTextEdit(edit: tsp.CodeEdit): lsp.TextEdit {
         },
         newText: edit.newText
     };
-}
-
-function tagsMarkdownPreview(tags: tsp.JSDocTagInfo[]): string {
-    return tags
-        .map(tag => {
-            const label = `*@${tag.name}*`;
-            if (!tag.text) {
-                return label;
-            }
-            let text: string;
-            if (typeof tag.text === 'string') {
-                text = tag.text;
-            } else {
-                text = tag.text?.map(p => p.text).join('') || '';
-            }
-            return label + (text.match(/\r\n|\n/g) ? '  \n' + text : ` — ${text}`);
-        })
-        .join('  \n\n');
-}
-
-export function toMarkDown(documentation: tsp.SymbolDisplayPart[], tags: tsp.JSDocTagInfo[]): string {
-    let result = '';
-    result += asPlainText(documentation);
-    const tagsPreview = tagsMarkdownPreview(tags);
-    if (tagsPreview) {
-        result += '\n\n' + tagsPreview;
-    }
-    return result;
 }
 
 export function toTextDocumentEdit(change: tsp.FileCodeEdits, documents: LspDocuments | undefined): lsp.TextDocumentEdit {
@@ -303,7 +275,7 @@ export function asPlainText(parts: tsp.SymbolDisplayPart[] | undefined): string 
     return parts.map(part => part.text).join('');
 }
 
-export namespace Position {
+namespace Position {
     export function Min(): undefined;
     export function Min(...positions: lsp.Position[]): lsp.Position;
     export function Min(...positions: lsp.Position[]): lsp.Position | undefined {

--- a/server/src/protocol-translation.ts
+++ b/server/src/protocol-translation.ts
@@ -213,12 +213,7 @@ export function asTagDocumentation(tag: tsp.JSDocTagInfo): string {
             if (!tag.text) {
                 break;
             }
-            let text: string;
-            if (typeof tag.text === 'string') {
-                text = tag.text;
-            } else {
-                text = asPlainText(tag.text);
-            }
+            const text = asPlainText(tag.text);
             const body = text.split(/^([\w.]+)\s*-?\s*/);
             if (body && body.length === 3) {
                 const param = body[1];

--- a/server/src/protocol-translation.ts
+++ b/server/src/protocol-translation.ts
@@ -138,18 +138,19 @@ export function toTextEdit(edit: tsp.CodeEdit): lsp.TextEdit {
 }
 
 function tagsMarkdownPreview(tags: tsp.JSDocTagInfo[]): string {
-    return (tags || [])
+    return tags
         .map(tag => {
             const label = `*@${tag.name}*`;
             if (!tag.text) {
                 return label;
             }
+            let text: string;
             if (typeof tag.text === 'string') {
-                return label + (tag.text.match(/\r\n|\n/g) ? '  \n' + tag.text : ` — ${tag.text}`);
+                text = tag.text;
+            } else {
+                text = tag.text?.map(p => p.text).join('') || '';
             }
-            return label + '  \n' + tag.text.map(symbolDisplayPart => {
-                return `* ${symbolDisplayPart.text} _${symbolDisplayPart.kind}_`;
-            }).join('\n');
+            return label + (text.match(/\r\n|\n/g) ? '  \n' + text : ` — ${text}`);
         })
         .join('  \n\n');
 }
@@ -238,15 +239,13 @@ export function asTagsDocumentation(tags: tsp.JSDocTagInfo[]): string {
 export function asTagDocumentation(tag: tsp.JSDocTagInfo): string {
     switch (tag.name) {
         case 'param': {
-            // TODO: What does this actually look like? Is the original logic
-            // just doing something that the new type should do?
-            let formattedTag = '';
+            let text: string;
             if (typeof tag.text === 'string') {
-                formattedTag = tag.text;
-            } else if (tag.text) {
-                formattedTag = tag.text.map(symbol => `${symbol.text} (${symbol.kind})`).join(', ');
+                text = tag.text;
+            } else {
+                text = tag.text?.map(p => p.text).join('') || '';
             }
-            const body = formattedTag.split(/^([\w.]+)\s*-?\s*/);
+            const body = text.split(/^([\w.]+)\s*-?\s*/);
             if (body && body.length === 3) {
                 const param = body[1];
                 const doc = body[2];
@@ -256,7 +255,7 @@ export function asTagDocumentation(tag: tsp.JSDocTagInfo): string {
                 }
                 return label + (doc.match(/\r\n|\n/g) ? '  \n' + doc : ` — ${doc}`);
             }
-            // fall-through
+            break;
         }
     }
 
@@ -274,26 +273,24 @@ export function asTagBodyText(tag: tsp.JSDocTagInfo): string | undefined {
         return undefined;
     }
 
-    // TODO: What does this actually look like? Is the original logic
-    // just doing something that the new type should do?
-    let formattedTag = '';
+    let text: string;
     if (typeof tag.text === 'string') {
-        formattedTag = tag.text;
-    } else if (tag.text) {
-        formattedTag = tag.text.map(symbol => `${symbol.text} (${symbol.kind})`).join(', ');
+        text = tag.text;
+    } else {
+        text = tag.text.map(p => p.text).join('');
     }
 
     switch (tag.name) {
         case 'example':
         case 'default':
             // Convert to markdown code block if it not already one
-            if (formattedTag.match(/^\s*[~`]{3}/g)) {
-                return formattedTag;
+            if (text.match(/^\s*[~`]{3}/g)) {
+                return text;
             }
-            return '```\n' + formattedTag + '\n```';
+            return '```\n' + text + '\n```';
     }
 
-    return formattedTag;
+    return text;
 }
 
 export function asPlainText(parts: undefined): undefined;

--- a/server/src/tsp-command-types.ts
+++ b/server/src/tsp-command-types.ts
@@ -18,12 +18,15 @@ and limitations under the License.
 ***************************************************************************** */
 
 export const enum CommandTypes {
+    JsxClosingTag = 'jsxClosingTag',
     Brace = 'brace',
     BraceCompletion = 'braceCompletion',
     GetSpanOfEnclosingComment = 'getSpanOfEnclosingComment',
     Change = 'change',
     Close = 'close',
+    /** @deprecated Prefer CompletionInfo -- see comment on CompletionsResponse */
     Completions = 'completions',
+    CompletionInfo = 'completionInfo',
     CompletionDetails = 'completionEntryDetails',
     CompileOnSaveAffectedFileList = 'compileOnSaveAffectedFileList',
     CompileOnSaveEmitFile = 'compileOnSaveEmitFile',
@@ -32,6 +35,7 @@ export const enum CommandTypes {
     DefinitionAndBoundSpan = 'definitionAndBoundSpan',
     Implementation = 'implementation',
     Exit = 'exit',
+    FileReferences = 'fileReferences',
     Format = 'format',
     Formatonkey = 'formatonkey',
     Geterr = 'geterr',
@@ -61,6 +65,7 @@ export const enum CommandTypes {
     OpenExternalProject = 'openExternalProject',
     OpenExternalProjects = 'openExternalProjects',
     CloseExternalProject = 'closeExternalProject',
+    UpdateOpen = 'updateOpen',
     GetOutliningSpans = 'getOutliningSpans',
     TodoComments = 'todoComments',
     Indentation = 'indentation',
@@ -73,7 +78,16 @@ export const enum CommandTypes {
     GetApplicableRefactors = 'getApplicableRefactors',
     GetEditsForRefactor = 'getEditsForRefactor',
     OrganizeImports = 'organizeImports',
-    GetEditsForFileRename = 'getEditsForFileRename'
+    GetEditsForFileRename = 'getEditsForFileRename',
+    ConfigurePlugin = 'configurePlugin',
+    SelectionRange = 'selectionRange',
+    ToggleLineComment = 'toggleLineComment',
+    ToggleMultilineComment = 'toggleMultilineComment',
+    CommentSelection = 'commentSelection',
+    UncommentSelection = 'uncommentSelection',
+    PrepareCallHierarchy = 'prepareCallHierarchy',
+    ProvideCallHierarchyIncomingCalls = 'provideCallHierarchyIncomingCalls',
+    ProvideCallHierarchyOutgoingCalls = 'provideCallHierarchyOutgoingCalls'
 }
 
 export const enum EventTypes {
@@ -152,5 +166,11 @@ export enum ScriptElementKind {
      */
     jsxAttribute = 'JSX attribute',
     /** String literal */
-    string = 'string'
+    string = 'string',
+    /** Jsdoc @link: in `{@link C link text}`, the before and after text "{@link " and "}" */
+    link = 'link',
+    /** Jsdoc @link: in `{@link C link text}`, the entity name "C" */
+    linkName = 'link name',
+    /** Jsdoc @link: in `{@link C link text}`, the link text "link text" */
+    linkText = 'link text'
 }

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -6,7 +6,7 @@
  */
 
 export class Deferred<T> {
-    resolve: (value?: T) => void;
+    resolve: (value: T) => void;
     reject: (err?: unknown) => void;
 
     promise = new Promise<T>((resolve, reject) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,17 +2,10 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@7.12.11":
+"@babel/code-frame@7.12.11", "@babel/code-frame@^7.0.0":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
   integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
-  dependencies:
-    "@babel/highlight" "^7.10.4"
-
-"@babel/code-frame@^7.0.0":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
-  integrity sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
   dependencies:
     "@babel/highlight" "^7.10.4"
 
@@ -938,16 +931,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/express-serve-static-core@*":
-  version "4.17.13"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.13.tgz#d9af025e925fc8b089be37423b8d1eac781be084"
-  integrity sha512-RgDi5a4nuzam073lRGKTUIaL3eF2+H7LJvJ8eUnCI0wA6SNjXc44DCmWNiTLs/AZ7QlsFWZiw/gTG3nSQGL0fA==
-  dependencies:
-    "@types/node" "*"
-    "@types/qs" "*"
-    "@types/range-parser" "*"
-
-"@types/express-serve-static-core@^4.17.18":
+"@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.18":
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.21.tgz#a427278e106bca77b83ad85221eae709a3414d42"
   integrity sha512-gwCiEZqW6f7EoR8TTEfalyEhb1zA5jQJnRngr97+3pzMaO1RKoI1w2bw07TK72renMUVWcWS5mLI6rk1NqN0nA==
@@ -998,12 +982,7 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-8.2.2.tgz#91daa226eb8c2ff261e6a8cbf8c7304641e095e0"
   integrity sha512-Lwh0lzzqT5Pqh6z61P3c3P5nm6fzQK/MMHl9UKeneAeInVflBSz1O2EkX6gM6xfJd7FBXBY5purtLx7fUiZ7Hw==
 
-"@types/node@*", "@types/node@>= 8":
-  version "14.11.8"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.8.tgz#fe2012f2355e4ce08bca44aeb3abbb21cf88d33f"
-  integrity sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==
-
-"@types/node@^15.12.4":
+"@types/node@*", "@types/node@>= 8", "@types/node@^15.12.4":
   version "15.12.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.4.tgz#e1cf817d70a1e118e81922c4ff6683ce9d422e26"
   integrity sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA==
@@ -2183,12 +2162,17 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+command-exists@1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.6.tgz#577f8e5feb0cb0f159cd557a51a9be1bdd76e09e"
+  integrity sha512-Qst/zUUNmS/z3WziPxyqjrcz09pm+2Knbs5mAZL4VAE0sSrNY1/w8+/YxeHcoBTsO6iojA6BW7eFf27Eg2MRuw==
+
 command-exists@^1.2.6:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.9.tgz#c50725af3808c8ab0260fd60b01fbfa25b954f69"
   integrity sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==
 
-commander@^2.20.0:
+commander@^2.11.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -2475,6 +2459,11 @@ crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
+
+crypto-random-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
+  integrity sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=
 
 crypto-random-string@^2.0.0:
   version "2.0.0"
@@ -3412,6 +3401,15 @@ fs-extra@^10.0.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
+fs-extra@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-extra@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
@@ -3604,22 +3602,10 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob@7.1.7, glob@^7.0.0, glob@^7.1.6:
+glob@7.1.7, glob@^7.0.0, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.7"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
   integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.1.1, glob@^7.1.3, glob@^7.1.4:
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
-  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -3647,12 +3633,7 @@ globby@^11.0.1, globby@^11.0.2, globby@^11.0.3:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
-  integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
-
-graceful-fs@^4.2.3, graceful-fs@^4.2.4:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.3, graceful-fs@^4.2.4:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
@@ -4391,6 +4372,13 @@ json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsonfile@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
@@ -4621,12 +4609,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@^4.17.15:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
-
-lodash@^4.17.19, lodash@^4.17.21, lodash@^4.7.0:
+lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -5115,12 +5098,12 @@ ms@2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-ms@2.1.2, ms@^2.0.0:
+ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3:
+ms@2.1.3, ms@^2.0.0:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -5539,6 +5522,11 @@ osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
+p-debounce@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-debounce/-/p-debounce-1.0.0.tgz#cb7f2cbeefd87a09eba861e112b67527e621e2fd"
+  integrity sha1-y38svu/YegnrqGHhErZ1J+Yh4v0=
+
 p-debounce@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-debounce/-/p-debounce-2.1.0.tgz#e79f70c6e325cbb9bddbcbec0b81025084671ad3"
@@ -5856,15 +5844,10 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-picomatch@^2.0.4, picomatch@^2.2.3:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
   integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
-
-picomatch@^2.2.1:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
-  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
@@ -6447,19 +6430,12 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.6, resolve@^1.20.0, resolve@^1.9.0:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.20.0, resolve@^1.9.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
   dependencies:
     is-core-module "^2.2.0"
-    path-parse "^1.0.6"
-
-resolve@^1.10.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
-  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
-  dependencies:
     path-parse "^1.0.6"
 
 restore-cursor@^3.1.0:
@@ -7179,6 +7155,14 @@ temp-write@^4.0.0:
     temp-dir "^1.0.0"
     uuid "^3.3.2"
 
+tempy@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tempy/-/tempy-0.2.1.tgz#9038e4dbd1c201b74472214179bc2c6f7776e54c"
+  integrity sha512-LB83o9bfZGrntdqPuRdanIVCPReam9SOZKW0fOy5I9X3A854GGWi0tjCqoXEk84XIEYBc/x9Hq3EFop/H5wJaw==
+  dependencies:
+    temp-dir "^1.0.0"
+    unique-string "^1.0.0"
+
 tempy@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tempy/-/tempy-1.0.1.tgz#30fe901fd869cfb36ee2bd999805aa72fbb035de"
@@ -7444,10 +7428,23 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.9.0:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript-language-server@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/typescript-language-server/-/typescript-language-server-0.5.1.tgz#266e8d85e58bae4b752ebb10b030404050928204"
+  integrity sha512-60Kguhwk/R1BB4pEIb6B9C7Ix7JzLzYnsODlmorYMPjMeEV0rCBqTR6FGAj4wVw/eHrHcpwLENmmURKUd8aybA==
+  dependencies:
+    command-exists "1.2.6"
+    commander "^2.11.0"
+    fs-extra "^7.0.0"
+    p-debounce "^1.0.0"
+    tempy "^0.2.1"
+    vscode-languageserver "^5.3.0-next"
+    vscode-uri "^1.0.5"
+
+typescript@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.4.tgz#3f85b986945bcf31071decdd96cf8bfa65f9dcbc"
+  integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
 
 uglify-js@^3.1.4:
   version "3.11.2"
@@ -7488,6 +7485,13 @@ unique-slug@^2.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
+unique-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
+  integrity sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=
+  dependencies:
+    crypto-random-string "^1.0.0"
+
 unique-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-2.0.0.tgz#39c6451f81afb2749de2b233e3f7c5e8843bd89d"
@@ -7499,6 +7503,11 @@ universal-user-agent@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
   integrity sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
 universalify@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This updates the project's TypeScript version from version 3.9.0 to 4.3.4.

I'm working on this in the context of https://github.com/apexskier/nova-typescript/issues/273, because I need to update types to properly type the `skipDestructiveCodeActions` arg.

There were fewer changes than I'd expect, here are the highlights:

* Several types in the tsserver protocol are now `string | tsp.SymbolDisplayPart[]` instead of `string`. I was originally playing with improving the formatting here, but decided not to include that in the scope of this change. (although I'd like to make some improvements separately)
* There are several new command types, so I've updated `server/src/tsp-command-types.ts`

Along with automated tests, I've been manually testing this underneath https://github.com/apexskier/nova-typescript and it seems to be working the same as before.