### PR TITLE
Only publish diagnostics if client supports the capability

### DIFF
--- a/server/src/lsp-server.spec.ts
+++ b/server/src/lsp-server.spec.ts
@@ -30,6 +30,10 @@ beforeEach(() => {
     server.closeAll();
 });
 
+after(() => {
+    server.closeAll();
+});
+
 describe('completion', () => {
     it('simple test', async () => {
         const doc = {
@@ -804,12 +808,12 @@ export function factory() {
 describe('diagnostics (no client support)', () => {
     before(async () => {
         // Remove the "textDocument.publishDiagnostics" client capability.
-        const clientCapabilitesOverride = getDefaultClientCapabilities();
-        delete clientCapabilitesOverride.textDocument?.publishDiagnostics;
+        const clientCapabilitiesOverride = getDefaultClientCapabilities();
+        delete clientCapabilitiesOverride.textDocument?.publishDiagnostics;
         server = await createServer({
             rootUri: null,
             publishDiagnostics: args => diagnostics.push(args),
-            clientCapabilitesOverride
+            clientCapabilitiesOverride
         });
     });
 
@@ -832,6 +836,6 @@ describe('diagnostics (no client support)', () => {
         await server.requestDiagnostics();
         await new Promise(resolve => setTimeout(resolve, 200));
         const diagnosticsForThisFile = diagnostics.filter(d => d!.uri === doc.uri);
-        assert.equal(diagnosticsForThisFile.length, 0, 'Unexpected diagnostics received');
+        assert.isEmpty(diagnosticsForThisFile, 'Unexpected diagnostics received');
     }).timeout(10000);
 });

--- a/server/src/lsp-server.spec.ts
+++ b/server/src/lsp-server.spec.ts
@@ -9,7 +9,7 @@ import * as chai from 'chai';
 import * as lsp from 'vscode-languageserver';
 import * as lspcalls from './lsp-protocol.calls.proposed';
 import { LspServer } from './lsp-server';
-import { uri, createServer, position, lastPosition, filePath } from './test-utils';
+import { uri, createServer, position, lastPosition, filePath, getDefaultClientCapabilities } from './test-utils';
 import { TextDocument } from 'vscode-languageserver';
 import { TSCompletionItem } from './completion';
 
@@ -843,5 +843,40 @@ export function factory() {
   ↖ ttt (do.ts#6) - do.ts#7
             `.trim()
         );
+    }).timeout(10000);
+});
+
+describe('diagnostics (no client support)', () => {
+    before(async () => {
+        // Remove the "textDocument.publishDiagnostics" client capability.
+        const clientCapabilitesOverride = getDefaultClientCapabilities();
+        delete clientCapabilitesOverride.textDocument?.publishDiagnostics;
+        server = await createServer({
+            rootUri: null,
+            publishDiagnostics: args => diagnostics.push(args),
+            clientCapabilitesOverride
+        });
+    });
+
+    it('no diagnostics are published', async () => {
+        const doc = {
+            uri: uri('diagnosticsBar.ts'),
+            languageId: 'typescript',
+            version: 1,
+            text: `
+        export function foo(): void {
+          missing('test')
+        }
+      `
+        };
+        server.didOpenTextDocument({
+            textDocument: doc
+        });
+
+        server.requestDiagnostics();
+        await server.requestDiagnostics();
+        await new Promise(resolve => setTimeout(resolve, 200));
+        const diagnosticsForThisFile = diagnostics.filter(d => d!.uri === doc.uri);
+        assert.equal(diagnosticsForThisFile.length, 0, 'Unexpected diagnostics received');
     }).timeout(10000);
 });

--- a/server/src/lsp-server.ts
+++ b/server/src/lsp-server.ts
@@ -948,7 +948,7 @@ export class LspServer {
             event.event === EventTypes.SyntaxDiag ||
             event.event === EventTypes.SuggestionDiag) {
             if (this.diagnosticQueue) {
-                this.diagnosticQueue.updateDiagnostics(event.event, event);
+                this.diagnosticQueue.updateDiagnostics(event.event, event as tsp.DiagnosticEvent);
             }
         } else {
             this.logger.log('Ignored event', {

--- a/server/src/lsp-server.ts
+++ b/server/src/lsp-server.ts
@@ -952,9 +952,7 @@ export class LspServer {
         if (event.event === EventTypes.SementicDiag ||
             event.event === EventTypes.SyntaxDiag ||
             event.event === EventTypes.SuggestionDiag) {
-            if (this.diagnosticQueue) {
-                this.diagnosticQueue.updateDiagnostics(event.event, event as tsp.DiagnosticEvent);
-            }
+            this.diagnosticQueue?.updateDiagnostics(event.event, event as tsp.DiagnosticEvent);
         } else {
             this.logger.log('Ignored event', {
                 event: event.event

--- a/server/src/test-utils.ts
+++ b/server/src/test-utils.ts
@@ -57,7 +57,7 @@ export async function createServer(options: {
     rootUri: string | null;
     tsserverLogVerbosity?: string;
     publishDiagnostics: (args: lsp.PublishDiagnosticsParams) => void;
-    clientCapabilitesOverride?: lsp.ClientCapabilities;
+    clientCapabilitiesOverride?: lsp.ClientCapabilities;
 }): Promise<LspServer> {
     const logger = new ConsoleLogger(false);
     const server = new LspServer({
@@ -85,7 +85,7 @@ export async function createServer(options: {
         rootPath: undefined,
         rootUri: options.rootUri,
         processId: 42,
-        capabilities: options.clientCapabilitesOverride || getDefaultClientCapabilities(),
+        capabilities: options.clientCapabilitiesOverride || getDefaultClientCapabilities(),
         workspaceFolders: null
     });
     return server;

--- a/server/src/test-utils.ts
+++ b/server/src/test-utils.ts
@@ -12,6 +12,17 @@ import { pathToUri } from './protocol-translation';
 import { LspServer } from './lsp-server';
 import { ConsoleLogger } from './logger';
 
+export function getDefaultClientCapabilities(): lsp.ClientCapabilities {
+    return {
+        textDocument: {
+            documentSymbol: {
+                hierarchicalDocumentSymbolSupport: true
+            },
+            publishDiagnostics: {}
+        }
+    };
+}
+
 export function uri(suffix = ''): string {
     const resolved = this.filePath(suffix);
     return pathToUri(resolved, undefined);
@@ -46,6 +57,7 @@ export async function createServer(options: {
     rootUri: string | null;
     tsserverLogVerbosity?: string;
     publishDiagnostics: (args: lsp.PublishDiagnosticsParams) => void;
+    clientCapabilitesOverride?: lsp.ClientCapabilities;
 }): Promise<LspServer> {
     const logger = new ConsoleLogger(false);
     const server = new LspServer({
@@ -73,13 +85,7 @@ export async function createServer(options: {
         rootPath: undefined,
         rootUri: options.rootUri,
         processId: 42,
-        capabilities: <any>{
-            textDocument: {
-                documentSymbol: {
-                    hierarchicalDocumentSymbolSupport: true
-                }
-            }
-        },
+        capabilities: options.clientCapabilitesOverride || getDefaultClientCapabilities(),
         workspaceFolders: null
     });
     return server;


### PR DESCRIPTION
Ensure that diagnostics are only published if client supports the
textDocument.publishDiagnostics capability.

Relates to #191