### PR TITLE
Add support for "unnecessary" and "deprecated" diagnostic tags

### DIFF
--- a/server/src/lsp-server.spec.ts
+++ b/server/src/lsp-server.spec.ts
@@ -174,7 +174,6 @@ describe('diagnostics', () => {
 
         await server.requestDiagnostics();
         await new Promise(resolve => setTimeout(resolve, 200));
-        // assert.deepEqual(JSON.stringify(diagnostics, null, 2), '');
         const resultsForFile = diagnostics.find(d => d!.uri === doc.uri);
         assert.isDefined(resultsForFile);
         const fileDiagnostics = resultsForFile!.diagnostics;

--- a/server/src/lsp-server.spec.ts
+++ b/server/src/lsp-server.spec.ts
@@ -15,7 +15,7 @@ import { TSCompletionItem } from './completion';
 
 const assert = chai.assert;
 
-let diagnostics: Array<lsp.PublishDiagnosticsParams | undefined>;
+let diagnostics: Array<lsp.PublishDiagnosticsParams>;
 
 let server: LspServer;
 
@@ -174,7 +174,7 @@ describe('diagnostics', () => {
 
         await server.requestDiagnostics();
         await new Promise(resolve => setTimeout(resolve, 200));
-        const resultsForFile = diagnostics.find(d => d!.uri === doc.uri);
+        const resultsForFile = diagnostics.find(d => d.uri === doc.uri);
         assert.isDefined(resultsForFile);
         const fileDiagnostics = resultsForFile!.diagnostics;
         assert.equal(fileDiagnostics.length, 2);

--- a/server/src/lsp-server.spec.ts
+++ b/server/src/lsp-server.spec.ts
@@ -162,12 +162,9 @@ describe('diagnostics', () => {
             version: 1,
             text: `
         import { join } from 'path';
-        /**
-         * @deprecated
-         */
-        function foo(): void {
-        }
 
+        /** @deprecated */
+        function foo(): void {}
         foo();
       `
         };

--- a/server/src/lsp-server.ts
+++ b/server/src/lsp-server.ts
@@ -99,6 +99,7 @@ export class LspServer {
             this.diagnosticQueue = new DiagnosticEventQueue(
                 diagnostics => this.options.lspClient.publishDiagnostics(diagnostics),
                 this.documents,
+                this.initializeParams.capabilities.textDocument.publishDiagnostics,
                 this.logger
             );
         }

--- a/server/src/test-utils.ts
+++ b/server/src/test-utils.ts
@@ -18,7 +18,9 @@ export function getDefaultClientCapabilities(): lsp.ClientCapabilities {
             documentSymbol: {
                 hierarchicalDocumentSymbolSupport: true
             },
-            publishDiagnostics: {}
+            publishDiagnostics: {
+                tagSupport: true
+            }
         }
     };
 }


### PR DESCRIPTION
Needed to pass client capability down the chain so that we don't add tags when client doesn't support them.

There are more fields on diagnostics that are only supported in later versions (not supported in current code base) so this will also be useful in the future.

@apexskier