### PR TITLE
Lookup tsserver using direct path rather than through .bin alias

### DIFF
--- a/server/src/lsp-server.ts
+++ b/server/src/lsp-server.ts
@@ -69,13 +69,14 @@ export class LspServer {
         if (this.options.tsserverPath) {
             return this.options.tsserverPath;
         }
+        const tsServerPath = path.join('typescript', 'lib', 'tsserver.js');
         // 1) look into .yarn/sdks of workspace root
-        const sdk = findPathToYarnSdk(this.rootPath(), path.join('typescript', 'lib', 'tsserver.js'));
+        const sdk = findPathToYarnSdk(this.rootPath(), tsServerPath);
         if (sdk) {
             return sdk;
         }
         // 2) look into node_modules of workspace root
-        const executable = findPathToModule(this.rootPath(), `.bin/${getTsserverExecutable()}`);
+        const executable = findPathToModule(this.rootPath(), tsServerPath);
         if (executable) {
             return executable;
         }
@@ -84,7 +85,7 @@ export class LspServer {
             return getTsserverExecutable();
         }
         // 4) look into node_modules of typescript-language-server
-        const bundled = findPathToModule(__dirname, path.join('typescript', 'lib', 'tsserver.js'));
+        const bundled = findPathToModule(__dirname, tsServerPath);
         if (!bundled) {
             throw Error(`Couldn't find '${getTsserverExecutable()}' executable or 'tsserver.js' module`);
         }

--- a/server/src/tsp-client.ts
+++ b/server/src/tsp-client.ts
@@ -105,7 +105,7 @@ export class TspClient {
         this.logger.info(`Starting tsserver : '${tsserverPath} ${args.join(' ')}'`);
         const tsserverPathIsModule = path.extname(tsserverPath) === '.js';
         this.tsserverProc = tsserverPathIsModule
-            ? cp.fork(tsserverPath, args, { silent: true })
+            ? cp.fork(tsserverPath, args, { silent: true, execArgv: [] })
             : cp.spawn(tsserverPath, args);
         this.readlineInterface = readline.createInterface(this.tsserverProc.stdout, this.tsserverProc.stdin, undefined);
         process.on('exit', () => {


### PR DESCRIPTION
Lookup the tsserver script through a more explicit typescript/lib/tsserver.js
path rather than through the alias created in the ".bin" directory. This
in theory is less future proof as the path to tsserver could change but
in practice it likely never will. And we also had other code paths
(yarn sdk lookup or lookup within this server's package) that used that
approach already so this unifies things more.

The side-effect of doing that is that we'll use "child_process.fork"
rather than "child_process.spawn" for starting the tsserver but we've
done that in other cases already and it seems like a better approach
anyway as then ENV will be inherited from the parent process (haven't
really verified that).

Also it fixes a corner case like #217 where "tsc" package is used and
makes the server fail.

Relates to #217